### PR TITLE
Fixed build, some sources were forgotten in CMakeLists.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,11 @@ PROJECT(${PROJECT_WX})
 SET(SOURCES
 	src/libui_sdl/main.cpp
 	src/libui_sdl/Platform.cpp
+        src/libui_sdl/LAN.cpp
 	src/libui_sdl/DlgAudioSettings.cpp
 	src/libui_sdl/DlgEmuSettings.cpp
 	src/libui_sdl/DlgInputConfig.cpp
+        src/libui_sdl/DlgWifiSettings.cpp
 	src/ARM.cpp
 	src/ARMInterpreter.cpp
 	src/ARMInterpreter_ALU.cpp

--- a/src/libui_sdl/DlgWifiSettings.cpp
+++ b/src/libui_sdl/DlgWifiSettings.cpp
@@ -204,9 +204,11 @@ void Open()
     int sel = 0;
     for (int i = 0; i < LAN::NumAdapters; i++)
     {
-        LAN::AdapterData* adapter = &LAN::Adapters[i];
-
-        uiComboboxAppend(cmAdapterList, adapter->FriendlyName);
+        LAN::AdapterData* adapter = &(LAN::Adapters[i]);
+        if (adapter->FriendlyName[0]) //are we on a system with friendly interface names?
+            uiComboboxAppend(cmAdapterList, adapter->FriendlyName);
+        else
+            uiComboboxAppend(cmAdapterList, adapter->DeviceName);
 
         if (!strncmp(adapter->DeviceName, Config::LANDevice, 128))
             sel = i;

--- a/src/libui_sdl/LAN.cpp
+++ b/src/libui_sdl/LAN.cpp
@@ -23,7 +23,8 @@
 #include <string.h>
 #include <SDL2/SDL.h>
 #include <pcap/pcap.h>
-#include "Wifi.h"
+#include <arpa/inet.h>
+#include "../Wifi.h"
 #include "LAN.h"
 #include "../Config.h"
 

--- a/src/libui_sdl/LAN.cpp
+++ b/src/libui_sdl/LAN.cpp
@@ -176,16 +176,16 @@ bool Init()
     while (dev != NULL)
     {
         adata->Internal = dev;
-        if (dev->name != NULL) { //crude, but it *mostly* works...
+        if (dev->name != NULL) { //crude, but it works...
             int len = strlen(dev->name);
             //len -= 12; //wha?
             if (len > 127) len = 127;
-            printf("Found Device %s\n", dev->name);
+            printf("PCap: Found Device %s\n", dev->name);
             strncpy(adata->DeviceName, dev->name, len);
             adata->DeviceName[len] = '\0';
             adata++;
         } else {
-            printf("WARNING: Unexpected null device name");
+            printf("PCap: ERROR: Unexpected null device name, expect a crash");
         }
         dev = dev->next;
     }
@@ -277,7 +277,33 @@ bool Init()
 
 #else
 
-    // TODO
+/*   //WIP: Get MAC and IP address on *nix
+    struct ifaddrs *ifaddr, *ifa;
+
+    if (getifaddrs(&ifaddr) == -1) {
+        printf("LAN: WARNING: Failed to get interface names
+    }
+
+    for (int i = 0; i < NumAdapters; i++)
+    {
+        adata = &Adapters[i];
+        for (ifa = ifaddr, n = 0; ifa != NULL; ifa = ifa->ifa_next, n++)
+        {
+            if (ifa->ifa_addr == NULL)
+                continue;
+            if (ifa->ifa_addr->sa_family != AF_PACKET)
+                continue;
+            if (strncmp(ifa->ifa_name, adata->DeviceName, 16))
+            {
+
+                
+
+            }
+        }
+    }
+
+    freeifaddrs(ifaddr);
+*/
 
 #endif // __WIN32__
 
@@ -298,6 +324,11 @@ bool Init()
     }
 
     pcap_freealldevs(alldevs);
+
+//this currently doesn't work on linux, it just hangs.
+//A better solution would be to encapsulate frames
+//in a custom protocol and use bog standard sockets.
+#ifdef __WIN32__
 
     for (int ntries = 0; ntries < 4; ntries++)
     {
@@ -365,6 +396,8 @@ bool Init()
 
         if (good) break;
     }
+
+#endif //__WIN32__
 
     if (pcap_setnonblock(PCapAdapter, 1, errbuf) < 0)
     {

--- a/src/libui_sdl/LAN.cpp
+++ b/src/libui_sdl/LAN.cpp
@@ -173,18 +173,21 @@ bool Init()
 
     AdapterData* adata = &Adapters[0];
     dev = alldevs;
-    while (dev)
+    while (dev != NULL)
     {
         adata->Internal = dev;
-
-        // hax
-        int len = strlen(dev->name);
-        len -= 12; if (len > 127) len = 127;
-        strncpy(adata->DeviceName, &dev->name[12], len);
-        adata->DeviceName[len] = '\0';
-
+        if (dev->name != NULL) { //crude, but it *mostly* works...
+            int len = strlen(dev->name);
+            //len -= 12; //wha?
+            if (len > 127) len = 127;
+            printf("Found Device %s\n", dev->name);
+            strncpy(adata->DeviceName, dev->name, len);
+            adata->DeviceName[len] = '\0';
+            adata++;
+        } else {
+            printf("WARNING: Unexpected null device name");
+        }
         dev = dev->next;
-        adata++;
     }
 
 #ifdef __WIN32__


### PR DESCRIPTION
Build broke due to linking errors, not being able to find `LAN::DeInit()` when it was very clearly there. attempting to manually point it at the object file revealed that it never got compiled, due to not being included in CMakeLists. This fixes that, as well as informing `LAN.cpp` the *proper* place for `Wifi.h`, and adding a missing include for the byte order functions. (`arpa/inet.h`)