### PR TITLE
Revamp CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,4 +32,3 @@ endif()
 configure_file(
 	${CMAKE_SOURCE_DIR}/romlist.bin
 	${CMAKE_BINARY_DIR}/romlist.bin COPYONLY)
-install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.10.2)
 
-cmake_policy(VERSION 3.13)
+cmake_policy(VERSION 3.10.2)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -22,11 +22,16 @@ if(ENABLE_LTO)
 endif()
 
 option(BUILD_LIBUI "Build libui frontend" ON)
+option(BUILD_SDL "Build SDL2 frontend" OFF)
 
 add_subdirectory(src)
 
 if (BUILD_LIBUI)
 	add_subdirectory(src/libui_sdl)
+endif()
+
+if (BUILD_SDL)
+	add_subdirectory(src/sdl)
 endif()
 
 configure_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.10.2)
 
 cmake_policy(VERSION 3.10.2)
+if (POLICY CMP0076)
+    cmake_policy(SET CMP0076 NEW)
+endif()
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,195 +1,35 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.13)
+
+cmake_policy(VERSION 3.13)
 
 set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
-SET(PROJECT_WX melonDS)
-PROJECT(${PROJECT_WX})
-
-SET(SOURCES
-	src/libui_sdl/main.cpp
-	src/libui_sdl/Platform.cpp
-	src/libui_sdl/PlatformConfig.cpp
-	src/libui_sdl/LAN_Socket.cpp
-	src/libui_sdl/LAN_PCap.cpp
-	src/libui_sdl/DlgAudioSettings.cpp
-	src/libui_sdl/DlgEmuSettings.cpp
-	src/libui_sdl/DlgInputConfig.cpp
-	src/libui_sdl/DlgWifiSettings.cpp
-	src/ARM.cpp
-	src/ARMInterpreter.cpp
-	src/ARMInterpreter_ALU.cpp
-	src/ARMInterpreter_Branch.cpp
-	src/ARMInterpreter_LoadStore.cpp
-	src/Config.cpp
-	src/CP15.cpp
-	src/CRC32.cpp
-	src/DMA.cpp
-	src/GPU.cpp
-	src/GPU2D.cpp
-	src/GPU3D.cpp
-	src/GPU3D_Soft.cpp
-	src/NDS.cpp
-	src/NDSCart.cpp
-	src/RTC.cpp
-	src/Savestate.cpp
-	src/SPI.cpp
-	src/SPU.cpp
-	src/Wifi.cpp
-	src/WifiAP.cpp
-	src/libui_sdl/libui/common/areaevents.c
-	src/libui_sdl/libui/common/control.c
-	src/libui_sdl/libui/common/debug.c
-	src/libui_sdl/libui/common/matrix.c
-	src/libui_sdl/libui/common/shouldquit.c
-	src/libui_sdl/libui/common/userbugs.c
-)
-
-if (UNIX)
-    LIST(APPEND SOURCES
-        src/libui_sdl/libui/unix/alloc.c
-        src/libui_sdl/libui/unix/area.c
-        src/libui_sdl/libui/unix/box.c
-        src/libui_sdl/libui/unix/button.c
-        src/libui_sdl/libui/unix/cellrendererbutton.c
-        src/libui_sdl/libui/unix/checkbox.c
-        src/libui_sdl/libui/unix/child.c
-        src/libui_sdl/libui/unix/colorbutton.c
-        src/libui_sdl/libui/unix/combobox.c
-        src/libui_sdl/libui/unix/control.c
-        src/libui_sdl/libui/unix/datetimepicker.c
-        src/libui_sdl/libui/unix/debug.c
-        src/libui_sdl/libui/unix/draw.c
-        src/libui_sdl/libui/unix/drawmatrix.c
-        src/libui_sdl/libui/unix/drawpath.c
-        src/libui_sdl/libui/unix/drawtext.c
-        src/libui_sdl/libui/unix/editablecombo.c
-        src/libui_sdl/libui/unix/entry.c
-        src/libui_sdl/libui/unix/fontbutton.c
-        src/libui_sdl/libui/unix/form.c
-        src/libui_sdl/libui/unix/future.c
-        src/libui_sdl/libui/unix/graphemes.c
-        src/libui_sdl/libui/unix/grid.c
-        src/libui_sdl/libui/unix/group.c
-        src/libui_sdl/libui/unix/image.c
-        src/libui_sdl/libui/unix/label.c
-        src/libui_sdl/libui/unix/main.c
-        src/libui_sdl/libui/unix/menu.c
-        src/libui_sdl/libui/unix/multilineentry.c
-        src/libui_sdl/libui/unix/progressbar.c
-        src/libui_sdl/libui/unix/radiobuttons.c
-        src/libui_sdl/libui/unix/separator.c
-        src/libui_sdl/libui/unix/slider.c
-        src/libui_sdl/libui/unix/spinbox.c
-        src/libui_sdl/libui/unix/stddialogs.c
-        src/libui_sdl/libui/unix/tab.c
-        src/libui_sdl/libui/unix/text.c
-        src/libui_sdl/libui/unix/util.c
-        src/libui_sdl/libui/unix/window.c
-        melon_grc.c
-    )
-
-    FIND_PACKAGE(PkgConfig REQUIRED)
-    PKG_CHECK_MODULES(GTK3 REQUIRED gtk+-3.0)
-    PKG_CHECK_MODULES(SDL2 REQUIRED sdl2)
-
-    INCLUDE_DIRECTORIES(${GTK3_INCLUDE_DIRS} ${SDL2_INCLUDE_DIRS})
-    LINK_LIBRARIES(${GTK3_LIBRARIES} ${SDL2_LIBRARIES})
-
-    ADD_DEFINITIONS(${GTK3_CFLAGS_OTHER})
-
-    add_custom_command(OUTPUT melon_grc.c
-        COMMAND glib-compile-resources --sourcedir="${CMAKE_CURRENT_SOURCE_DIR}"
-                --target="${CMAKE_CURRENT_BINARY_DIR}/melon_grc.c"
-                --generate-source "${CMAKE_CURRENT_SOURCE_DIR}/melon_grc.xml"
-        COMMAND glib-compile-resources --sourcedir="${CMAKE_CURRENT_SOURCE_DIR}"
-                --target="${CMAKE_CURRENT_BINARY_DIR}/melon_grc.h"
-                --generate-header "${CMAKE_CURRENT_SOURCE_DIR}/melon_grc.xml")
-
-    if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-        LINK_LIBRARIES("dl")
-    endif ()
-elseif (WIN32)
-    LIST(APPEND SOURCES
-        src/libui_sdl/libui/windows/alloc.cpp
-        src/libui_sdl/libui/windows/area.cpp
-        src/libui_sdl/libui/windows/areadraw.cpp
-        src/libui_sdl/libui/windows/areaevents.cpp
-        src/libui_sdl/libui/windows/areascroll.cpp
-        src/libui_sdl/libui/windows/areautil.cpp
-        src/libui_sdl/libui/windows/box.cpp
-        src/libui_sdl/libui/windows/button.cpp
-        src/libui_sdl/libui/windows/checkbox.cpp
-        src/libui_sdl/libui/windows/colorbutton.cpp
-        src/libui_sdl/libui/windows/colordialog.cpp
-        src/libui_sdl/libui/windows/combobox.cpp
-        src/libui_sdl/libui/windows/container.cpp
-        src/libui_sdl/libui/windows/control.cpp
-        src/libui_sdl/libui/windows/d2dscratch.cpp
-        src/libui_sdl/libui/windows/datetimepicker.cpp
-        src/libui_sdl/libui/windows/debug.cpp
-        src/libui_sdl/libui/windows/draw.cpp
-        src/libui_sdl/libui/windows/drawmatrix.cpp
-        src/libui_sdl/libui/windows/drawpath.cpp
-        src/libui_sdl/libui/windows/drawtext.cpp
-        src/libui_sdl/libui/windows/dwrite.cpp
-        src/libui_sdl/libui/windows/editablecombo.cpp
-        src/libui_sdl/libui/windows/entry.cpp
-        src/libui_sdl/libui/windows/events.cpp
-        src/libui_sdl/libui/windows/fontbutton.cpp
-        src/libui_sdl/libui/windows/fontdialog.cpp
-        src/libui_sdl/libui/windows/form.cpp
-        src/libui_sdl/libui/windows/graphemes.cpp
-        src/libui_sdl/libui/windows/grid.cpp
-        src/libui_sdl/libui/windows/group.cpp
-        src/libui_sdl/libui/windows/init.cpp
-        src/libui_sdl/libui/windows/label.cpp
-        src/libui_sdl/libui/windows/main.cpp
-        src/libui_sdl/libui/windows/menu.cpp
-        src/libui_sdl/libui/windows/multilineentry.cpp
-        src/libui_sdl/libui/windows/parent.cpp
-        src/libui_sdl/libui/windows/progressbar.cpp
-        src/libui_sdl/libui/windows/radiobuttons.cpp
-        src/libui_sdl/libui/windows/separator.cpp
-        src/libui_sdl/libui/windows/sizing.cpp
-        src/libui_sdl/libui/windows/slider.cpp
-        src/libui_sdl/libui/windows/spinbox.cpp
-        src/libui_sdl/libui/windows/stddialogs.cpp
-        #src/libui_sdl/libui/windows/tab.cpp
-        #src/libui_sdl/libui/windows/tabpage.cpp
-        src/libui_sdl/libui/windows/text.cpp
-        src/libui_sdl/libui/windows/utf16.cpp
-        src/libui_sdl/libui/windows/utilwin.cpp
-        src/libui_sdl/libui/windows/window.cpp
-        src/libui_sdl/libui/windows/winpublic.cpp
-        src/libui_sdl/libui/windows/winutil.cpp
-        src/libui_sdl/libui/windows/resources.rc
-		melon.rc
-    )
-
-    LINK_LIBRARIES("comctl32")
-    LINK_LIBRARIES("d2d1")
-    LINK_LIBRARIES("dwrite")
-    LINK_LIBRARIES("usp10")
-    LINK_LIBRARIES("ws2_32")
-    LINK_LIBRARIES("uxtheme")
-endif (UNIX)
-
-find_package(SDL2 REQUIRED)
-include_directories(${SDL2_INCLUDE_DIR})
-string(STRIP ${SDL2_LIBRARIES} SDL2_LIBRARIES)
-link_libraries(${SDL2_LIBRARIES})
-
-add_executable(${PROJECT_WX} ${SOURCES})
-target_link_libraries(${PROJECT_WX})
+project(melonDS)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-if(CMAKE_BUILD_TYPE STREQUAL Debug)
-set(CMAKE_CXX_FLAGS "-g")
-elseif(CMAKE_BUILD_TYPE STREQUAL Release)
-set(CMAKE_CXX_FLAGS "-O3 -flto")
+if (CMAKE_BUILD_TYPE STREQUAL Release)
+	option(ENABLE_LTO "Enable link-time optimization" ON)
+else()
+	option(ENABLE_LTO "Enable link-time optimization" OFF)
 endif()
 
-install(TARGETS ${PROJECT_WX} RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+if(ENABLE_LTO)
+	add_compile_options(-flto)
+endif()
+
+option(BUILD_LIBUI "Build libui frontend" ON)
+
+add_subdirectory(src)
+
+if (BUILD_LIBUI)
+	add_subdirectory(src/libui_sdl)
+endif()
+
+configure_file(
+	${CMAKE_SOURCE_DIR}/romlist.bin
+	${CMAKE_BINARY_DIR}/romlist.bin COPYONLY)
+install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ make
 #### MSYS2 and CMake
 
 1. Install [MSYS2](https://www.msys2.org/)
-2. Open the **MSYS2 MingW 64-bit** terminal
+2. Open the **MSYS2 MinGW 64-bit** terminal
 3. Update the packages using `pacman -Syu` and reopen the terminal if it asks you to
 4. Install dependencies: `pacman -S mingw-w64-x86_64-{toolchain,SDL2,cmake} make git`
 5. Run the following commands

--- a/README.md
+++ b/README.md
@@ -55,9 +55,25 @@ make
 ### Windows:
 
  * use CodeBlocks
- * or receive golden cookies if you get Cmake to work
 
-Build system is not set in stone.
+#### MSYS2 and CMake
+
+1. Install [MSYS2](https://www.msys2.org/)
+2. Open the **MSYS2 MingW 64-bit** terminal
+3. Update the packages using `pacman -Syu` and reopen the terminal if it asks you to
+4. Install dependencies: `pacman -S mingw-w64-x86_64-{toolchain,SDL2,cmake} make git`
+5. Run the following commands
+   ```bash
+   git clone https://github.com/Arisotura/melonDS.git
+   cd melonDS
+   mkdir build
+   cd build
+   cmake .. -G "MSYS Makefiles"
+   make -j5
+   ../msys-dist.sh
+   ```
+
+If everything went well, melonDS and the libraries it needs should now be in the `dist` folder.
 
 ## TODO LIST
 

--- a/msys-dist.sh
+++ b/msys-dist.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [[ ! -x melonDS.exe ]]; then
+	echo "Run this script from the directory you built melonDS."
+	exit 1
+fi
+
+mkdir -p dist
+
+for lib in $(ldd melonDS.exe | grep mingw | sed "s/.*=> //" | sed "s/(.*)//"); do
+	cp "${lib}" dist
+done
+
+cp melonDS.exe romlist.bin dist

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,29 @@
+project(core)
+
+add_library(core STATIC
+	ARM.cpp
+	ARMInterpreter.cpp
+	ARMInterpreter_ALU.cpp
+	ARMInterpreter_Branch.cpp
+	ARMInterpreter_LoadStore.cpp
+	Config.cpp
+	CP15.cpp
+	CRC32.cpp
+	DMA.cpp
+	GPU.cpp
+	GPU2D.cpp
+	GPU3D.cpp
+	GPU3D_Soft.cpp
+	NDS.cpp
+	NDSCart.cpp
+	RTC.cpp
+	Savestate.cpp
+	SPI.cpp
+	SPU.cpp
+	Wifi.cpp
+	WifiAP.cpp
+)
+
+if (WIN32)
+	target_link_libraries(core ole32 comctl32 ws2_32)
+endif()

--- a/src/libui_sdl/CMakeLists.txt
+++ b/src/libui_sdl/CMakeLists.txt
@@ -36,13 +36,6 @@ if (UNIX)
 
 	ADD_DEFINITIONS(${GTK3_CFLAGS_OTHER})
 
-	#	add_custom_command(OUTPUT melon_grc.c
-	#	COMMAND glib-compile-resources
-	#			--sourcedir="${CMAKE_SOURCE_DIR}"
-	#			--target="${CMAKE_CURRENT_BINARY_DIR}/melon_grc.c"
-	#			--generate-source --generate-header
-	#			"${CMAKE_SOURCE_DIR}/melon_grc.xml"
-	#	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 	add_custom_command(OUTPUT melon_grc.c
 		COMMAND glib-compile-resources --sourcedir="${CMAKE_SOURCE_DIR}"
 				--target="${CMAKE_CURRENT_BINARY_DIR}/melon_grc.c"

--- a/src/libui_sdl/CMakeLists.txt
+++ b/src/libui_sdl/CMakeLists.txt
@@ -1,0 +1,71 @@
+project(libui_sdl)
+
+SET(SOURCES_LIBUI
+	main.cpp
+	Platform.cpp
+	PlatformConfig.cpp
+	LAN_Socket.cpp
+	LAN_PCap.cpp
+	DlgAudioSettings.cpp
+	DlgEmuSettings.cpp
+	DlgInputConfig.cpp
+	DlgWifiSettings.cpp
+	#libui/common/areaevents.c
+	#libui/common/control.c
+	#libui/common/debug.c
+	#libui/common/matrix.c
+	#libui/common/shouldquit.c
+	#libui/common/userbugs.c
+)
+
+option(BUILD_SHARED_LIBS "Whether to build libui as a shared library or a static library" ON)
+set(BUILD_SHARED_LIBS OFF)
+add_subdirectory(libui)
+
+find_package(SDL2 REQUIRED)
+include_directories(${SDL2_INCLUDE_DIR})
+#string(STRIP ${SDL2_LIBRARIES} SDL2_LIBRARIES)
+
+add_executable(melonDS ${SOURCES_LIBUI})
+target_link_libraries(melonDS
+	core ${SDL2_LIBRARIES} libui)
+
+if (UNIX)
+	find_package(PkgConfig REQUIRED)
+	pkg_check_modules(GTK3 REQUIRED gtk+-3.0)
+	pkg_check_modules(SDL2 REQUIRED sdl2)
+
+	target_include_directories(melonDS
+		PRIVATE ${GTK3_INCLUDE_DIRS} ${SDL2_INCLUDE_DIRS}
+	)
+	target_link_libraries(melonDS ${GTK3_LIBRARIES} ${SDL2_LIBRARIES})
+
+	ADD_DEFINITIONS(${GTK3_CFLAGS_OTHER})
+
+	#	add_custom_command(OUTPUT melon_grc.c
+	#	COMMAND glib-compile-resources
+	#			--sourcedir="${CMAKE_SOURCE_DIR}"
+	#			--target="${CMAKE_CURRENT_BINARY_DIR}/melon_grc.c"
+	#			--generate-source --generate-header
+	#			"${CMAKE_SOURCE_DIR}/melon_grc.xml"
+	#	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+	add_custom_command(OUTPUT melon_grc.c
+		COMMAND glib-compile-resources --sourcedir="${CMAKE_SOURCE_DIR}"
+				--target="${CMAKE_CURRENT_BINARY_DIR}/melon_grc.c"
+				--generate-source "${CMAKE_SOURCE_DIR}/melon_grc.xml"
+		COMMAND glib-compile-resources --sourcedir="${CMAKE_SOURCE_DIR}"
+				--target="${CMAKE_CURRENT_BINARY_DIR}/melon_grc.h"
+				--generate-header "${CMAKE_SOURCE_DIR}/melon_grc.xml")
+
+	if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+		target_link_libraries(melonDS dl)
+	endif ()
+
+	target_sources(melonDS PUBLIC melon_grc.c)
+elseif (WIN32)
+	target_sources(melonDS PUBLIC "${CMAKE_SOURCE_DIR}/melon.rc")
+	target_include_directories(melonDS PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/..")
+	target_link_libraries(melonDS comctl32 d2d1 dwrite uxtheme ws2_32 iphlpapi)
+endif ()
+
+install(TARGETS melonDS RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)

--- a/src/libui_sdl/CMakeLists.txt
+++ b/src/libui_sdl/CMakeLists.txt
@@ -10,12 +10,6 @@ SET(SOURCES_LIBUI
 	DlgEmuSettings.cpp
 	DlgInputConfig.cpp
 	DlgWifiSettings.cpp
-	#libui/common/areaevents.c
-	#libui/common/control.c
-	#libui/common/debug.c
-	#libui/common/matrix.c
-	#libui/common/shouldquit.c
-	#libui/common/userbugs.c
 )
 
 option(BUILD_SHARED_LIBS "Whether to build libui as a shared library or a static library" ON)


### PR DESCRIPTION
This is almost an entire rewrite of the CMake build system that
- Splits the build script up into different files to make it easier to build for example a libretro core or some other new frontend
- Uses libui's existing build system instead of needlessly doing it ourselves
- Finally builds correctly on MSYS2 on Windows with no changes
- Copies `romlist.bin` to the build directory

I've also added build instructions for Windows to the readme and written a small script to copy the needed files to run it to a directory that can be distributed.