### PR TITLE
Firmware backup writing now uses OpenLocalFile

### DIFF
--- a/src/SPI.cpp
+++ b/src/SPI.cpp
@@ -130,11 +130,11 @@ void Reset()
 
     // take a backup
     const char* firmbkp = "firmware.bin.bak";
-    f = fopen(firmbkp, "rb");
+    f = Platform::OpenLocalFile(firmbkp, "rb");
     if (f) fclose(f);
     else
     {
-        f = fopen(firmbkp, "wb");
+        f = Platform::OpenLocalFile(firmbkp, "wb");
         fwrite(Firmware, 1, FirmwareLength, f);
         fclose(f);
     }


### PR DESCRIPTION
When writing the firmware backup, `fopen()` was being used, instead of `Platform::OpenLocalFile()`, which was not consistent with the rest of the code base.