### PR TITLE
Fix the build on MinGW

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,9 +13,11 @@ add_library(core STATIC
 	GPU.cpp
 	GPU2D.cpp
 	GPU3D.cpp
+	GPU3D_OpenGL.cpp
 	GPU3D_Soft.cpp
 	NDS.cpp
 	NDSCart.cpp
+	OpenGLSupport.cpp
 	RTC.cpp
 	Savestate.cpp
 	SPI.cpp
@@ -25,5 +27,5 @@ add_library(core STATIC
 )
 
 if (WIN32)
-	target_link_libraries(core ole32 comctl32 ws2_32)
+	target_link_libraries(core ole32 comctl32 ws2_32 opengl32)
 endif()

--- a/src/libui_sdl/CMakeLists.txt
+++ b/src/libui_sdl/CMakeLists.txt
@@ -9,6 +9,7 @@ SET(SOURCES_LIBUI
 	DlgAudioSettings.cpp
 	DlgEmuSettings.cpp
 	DlgInputConfig.cpp
+	DlgVideoSettings.cpp
 	DlgWifiSettings.cpp
 )
 

--- a/src/libui_sdl/libui/windows/CMakeLists.txt
+++ b/src/libui_sdl/libui/windows/CMakeLists.txt
@@ -29,6 +29,7 @@ list(APPEND _LIBUI_SOURCES
 	windows/fontbutton.cpp
 	windows/fontdialog.cpp
 	windows/form.cpp
+	windows/gl.cpp
 	windows/graphemes.cpp
 	windows/grid.cpp
 	windows/group.cpp


### PR DESCRIPTION
Fixes linking errors by adding missing files to CMake and linking to `libopengl32`.