### PR TITLE
Make OpenGL renderer work on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ obj
 *.o
 melon_grc.c
 melon_grc.h
+cmake-build

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,8 +22,13 @@ add_library(core STATIC
 	SPU.cpp
 	Wifi.cpp
 	WifiAP.cpp
+	# opengl backend stuff
+	GPU3D_OpenGL.cpp
+	OpenGLSupport.cpp
 )
 
 if (WIN32)
 	target_link_libraries(core ole32 comctl32 ws2_32)
+else()
+	target_link_libraries(core OpenGL)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,7 +28,7 @@ add_library(core STATIC
 )
 
 if (WIN32)
-	target_link_libraries(core ole32 comctl32 ws2_32)
+	target_link_libraries(core ole32 comctl32 ws2_32 opengl32)
 else()
 	target_link_libraries(core OpenGL)
 endif()

--- a/src/OpenGLSupport.cpp
+++ b/src/OpenGLSupport.cpp
@@ -18,6 +18,8 @@
 
 #include "OpenGLSupport.h"
 
+#include <cstring>
+
 
 DO_PROCLIST(DECLPROC);
 

--- a/src/libui_sdl/CMakeLists.txt
+++ b/src/libui_sdl/CMakeLists.txt
@@ -10,6 +10,8 @@ SET(SOURCES_LIBUI
 	DlgEmuSettings.cpp
 	DlgInputConfig.cpp
 	DlgWifiSettings.cpp
+	# opengl backend stuff
+	DlgVideoSettings.cpp
 )
 
 option(BUILD_SHARED_LIBS "Whether to build libui as a shared library or a static library" ON)

--- a/src/libui_sdl/libui/unix/CMakeLists.txt
+++ b/src/libui_sdl/libui/unix/CMakeLists.txt
@@ -43,6 +43,7 @@ list(APPEND _LIBUI_SOURCES
 	unix/text.c
 	unix/util.c
 	unix/window.c
+	unix/gl.c
 )
 set(_LIBUI_SOURCES ${_LIBUI_SOURCES} PARENT_SCOPE)
 

--- a/src/libui_sdl/libui/unix/gl.c
+++ b/src/libui_sdl/libui/unix/gl.c
@@ -1,0 +1,47 @@
+// 26 may 2019
+#include "uipriv_unix.h"
+
+/*
+ *(melonDS:17013): Gtk-CRITICAL **: 00:28:09.095: gtk_gl_area_set_required_version: assertion 'GTK_IS_GL_AREA (area)' failed
+
+(melonDS:17013): GLib-GObject-WARNING **: 00:28:09.096: invalid cast from 'GtkGLArea' to 'areaWidget'
+ */
+
+struct uiGLContext {
+	GtkGLArea *gla;
+	GdkGLContext *gctx;
+	int vermaj, vermin;
+};
+
+uiGLContext *createGLContext(GtkGLArea* gla, int maj, int min)
+{
+	uiGLContext *ret = uiAlloc(sizeof(uiGLContext), "uiGLContext");
+	ret->gla = gla;
+	ret->gctx = gtk_gl_area_get_context(gla);
+	ret->vermaj = maj; ret->vermin = min;
+	return ret;
+}
+
+void uiGLSwapBuffers(uiGLContext* ctx)
+{
+	if (!ctx) return;
+	gtk_gl_area_attach_buffers(ctx->gla);
+}
+
+void uiGLMakeContextCurrent(uiGLContext* ctx)
+{
+	if (!ctx) return;
+	gtk_gl_area_make_current(ctx->gla);
+}
+void *uiGLGetProcAddress(const char* proc)
+{
+	// this *will* break for older systems that don't have libglvnd!
+	// TODO: use a real solution
+	return dlsym(NULL /* RTLD_DEFAULT */, proc);
+}
+unsigned int uiGLGetVersion(uiGLContext* ctx)
+{
+	if (!ctx) return 0;
+	return uiGLVersion(ctx->vermaj, ctx->vermin);
+}
+

--- a/src/libui_sdl/libui/unix/uipriv_unix.h
+++ b/src/libui_sdl/libui/unix/uipriv_unix.h
@@ -5,7 +5,7 @@
 #define GDK_VERSION_MAX_ALLOWED GDK_VERSION_3_10
 #include <gtk/gtk.h>
 #include <math.h>
-#include <dlfcn.h>		// see drawtext.c
+#include <dlfcn.h>		// see drawtext.c, gl.c
 #include <langinfo.h>
 #include <string.h>
 #include <stdlib.h>
@@ -63,3 +63,7 @@ extern GtkCellRenderer *newCellRendererButton(void);
 extern void loadFutures(void);
 extern PangoAttribute *FUTURE_pango_attr_foreground_alpha_new(guint16 alpha);
 extern gboolean FUTURE_gtk_widget_path_iter_set_object_name(GtkWidgetPath *path, gint pos, const char *name);
+
+// gl.c
+extern uiGLContext *createGLContext(GtkGLArea* gla, int maj, int min);
+

--- a/src/libui_sdl/libui/unix/window.c
+++ b/src/libui_sdl/libui/unix/window.c
@@ -102,6 +102,23 @@ static void uiWindowDestroy(uiControl *c)
 	uiFreeControl(uiControl(w));
 }
 
+void uiWindowSetPosition(uiWindow *w, int x, int y)
+{
+	if (!w) return;
+
+	gtk_window_move(w->window, x, y);
+}
+
+void uiWindowPosition(uiWindow *w, int *x, int *y)
+{
+	if (!w) return;
+
+	int xx, yy;
+	gtk_window_get_position(w->window, &xx, &yy);
+	if (x) *x = xx;
+	if (y) *y = yy;
+}
+
 uiUnixControlDefaultHandle(uiWindow)
 
 uiControl *uiWindowParent(uiControl *c)
@@ -442,3 +459,4 @@ uiWindow *uiNewWindow(const char *title, int width, int height, int maximized, i
 
 	return w;
 }
+

--- a/src/libui_sdl/libui/windows/CMakeLists.txt
+++ b/src/libui_sdl/libui/windows/CMakeLists.txt
@@ -29,6 +29,7 @@ list(APPEND _LIBUI_SOURCES
 	windows/fontbutton.cpp
 	windows/fontdialog.cpp
 	windows/form.cpp
+	windows/gl.cpp
 	windows/graphemes.cpp
 	windows/grid.cpp
 	windows/group.cpp


### PR DESCRIPTION
There's still a memory leak:

```
** (melonDS:18811): CRITICAL **: 00:44:36.831: [libui] /home/poro/src/sspt-pkgs/melonDS/src/libui_sdl/libui/unix/alloc.c:42:uninitAlloc() You have a bug: Some data was leaked; either you left a uiControl lying around or there's a bug in libui itself. Leaked data:
0xf82192b8a70 uiGLContext
0xf82192f4f80 uiGLContext
```

But who cares, that data is allocated once at startup, and lasts for pretty much the entire life of the process.