### PR TITLE
Linux: Fix issue where melonDS.ini is created with \ in name

### DIFF
--- a/src/libui_sdl/Platform.cpp
+++ b/src/libui_sdl/Platform.cpp
@@ -167,7 +167,13 @@ FILE* OpenLocalFile(const char* path, const char* mode)
         int len = emudirlen + 1 + pathlen + 1;
         emudirpath = new char[len];
         strncpy(&emudirpath[0], EmuDirectory, emudirlen);
+
+#ifdef __WIN32__
         emudirpath[emudirlen] = '\\';
+#else
+        emudirpath[emudirlen] = '/';
+#endif
+
         strncpy(&emudirpath[emudirlen+1], path, pathlen);
         emudirpath[emudirlen+1+pathlen] = '\0';
     }


### PR DESCRIPTION
Should fix #413.

I found out that this issue wasn't because I ran it in a terminal, but whenever there was no config in any of the valid locations and it creates a new one in the emulator directory.