### PR TITLE
cmake: bump minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.13)
 
-cmake_policy(VERSION 3.10.2)
+cmake_policy(VERSION 3.13)
 if (POLICY CMP0076)
     cmake_policy(SET CMP0076 NEW)
 endif()


### PR DESCRIPTION
`add_link_options()` only exists on cmake >=3.13. Closes #441.