### PR TITLE
Fix crash on esc when in menus on Windows

### DIFF
--- a/src/libui_sdl/libui/windows/window.cpp
+++ b/src/libui_sdl/libui/windows/window.cpp
@@ -95,7 +95,8 @@ static LRESULT CALLBACK windowWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARA
 		// not a menu
 		if (lParam != 0)
 			break;
-		if (HIWORD(wParam) != 0)
+		// IDOK (1) and IDCANCEL (2) aren't menu events either
+		if (HIWORD(wParam) != 0 || LOWORD(wParam) <= IDCANCEL)
 			break;
 		runMenuEvent(LOWORD(wParam), uiWindow(w));
 		return 0;


### PR DESCRIPTION
Fixes the crash mentioned in #471 by merging [ee87a9](https://github.com/andlabs/libui/commit/ee87a9db2383fd9333b3bb41644c3f06c9ae21be) from libui