### PR TITLE
Add warning message if romlist.bin is not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ obj
 melon_grc.c
 melon_grc.h
 cmake-build
+cmake-build-debug
+.idea

--- a/src/libui_sdl/main.cpp
+++ b/src/libui_sdl/main.cpp
@@ -2573,7 +2573,6 @@ int main(int argc, char** argv)
         SDL_Quit();
         return 0;
     }
-
     {
         FILE* f = Platform::OpenLocalFile("romlist.bin", "rb");
         if (f)
@@ -2589,6 +2588,13 @@ int main(int argc, char** argv)
                               "Save memory type detection will not work correctly.\n\n"
                               "You should use the latest version of romlist.bin (provided in melonDS release packages).");
             }
+        }
+        else
+        {
+        	uiMsgBoxError(NULL,
+        			     "romlist.bin not found.",
+        			     "Save memory type detection will not work correctly.\n\n"
+				         "You should use the latest version of romlist.bin (provided in melonDS release packages).");
         }
     }
 


### PR DESCRIPTION
This will hopefully help to avoid guys like me loosing saved due to missing romlist.bin.
Will probably come in handy when someone uses melonDS later and makes a mistake.