### PR TITLE
Fix cmake resource file compilation issues

### DIFF
--- a/src/libui_sdl/CMakeLists.txt
+++ b/src/libui_sdl/CMakeLists.txt
@@ -14,6 +14,10 @@ SET(SOURCES_LIBUI
 	OSD.cpp
 )
 
+if (WIN32)
+	set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> -i <SOURCE> -o <OBJECT>")
+endif()
+
 option(BUILD_SHARED_LIBS "Whether to build libui as a shared library or a static library" ON)
 set(BUILD_SHARED_LIBS OFF)
 add_subdirectory(libui)

--- a/src/libui_sdl/CMakeLists.txt
+++ b/src/libui_sdl/CMakeLists.txt
@@ -43,11 +43,11 @@ if (UNIX)
 	ADD_DEFINITIONS(${GTK3_CFLAGS_OTHER})
 
 	add_custom_command(OUTPUT melon_grc.c
-		COMMAND glib-compile-resources --sourcedir="${CMAKE_SOURCE_DIR}"
-				--target="${CMAKE_CURRENT_BINARY_DIR}/melon_grc.c"
+		COMMAND glib-compile-resources --sourcedir=${CMAKE_SOURCE_DIR}
+				--target=${CMAKE_CURRENT_BINARY_DIR}/melon_grc.c
 				--generate-source "${CMAKE_SOURCE_DIR}/melon_grc.xml"
-		COMMAND glib-compile-resources --sourcedir="${CMAKE_SOURCE_DIR}"
-				--target="${CMAKE_CURRENT_BINARY_DIR}/melon_grc.h"
+		COMMAND glib-compile-resources --sourcedir=${CMAKE_SOURCE_DIR}
+				--target=${CMAKE_CURRENT_BINARY_DIR}/melon_grc.h
 				--generate-header "${CMAKE_SOURCE_DIR}/melon_grc.xml")
 
 	if (CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/src/libui_sdl/libui/windows/CMakeLists.txt
+++ b/src/libui_sdl/libui/windows/CMakeLists.txt
@@ -73,7 +73,7 @@ macro(_handle_static)
 	add_custom_command(
 		TARGET libui POST_BUILD
 		COMMAND
-			${CMAKE_COMMAND} -E copy $<TARGET_PROPERTY:libui,BINARY_DIR>/CMakeFiles/libui.dir/windows/resources.rc.* ${_LIBUI_STATIC_RES}
+			${CMAKE_COMMAND} -E copy $<TARGET_PROPERTY:libui,BINARY_DIR>/CMakeFiles/libui.dir/windows/resources.rc.obj ${_LIBUI_STATIC_RES}
 		COMMENT "Copying libui.res")
 endmacro()
 


### PR DESCRIPTION
Should fix https://github.com/Arisotura/melonDS/issues/307 ~~and https://github.com/Arisotura/melonDS/issues/507~~
Nevermind, just saw that the output of https://github.com/Arisotura/melonDS/issues/507 should only be generated for Linux builds anyway so this shouldn't have any effect on that.

(untested with an MSVC setup, might require an additional `if(NOT MSVC)` if it causes issues there)