### PR TITLE
Update net.kuribo64.melonds.desktop

### DIFF
--- a/flatpak/net.kuribo64.melonds.desktop
+++ b/flatpak/net.kuribo64.melonds.desktop
@@ -1,8 +1,9 @@
 [Desktop Entry]
 Name=melonDS
 Comment=Nintendo DS emulator
+GenericName=Nintendo DS emulator
 Exec=melonDS
 Type=Application
-Categories=Game;
+Categories=Game;Emulator;
 Terminal=false
 Icon=net.kuribo64.melonds


### PR DESCRIPTION
"GenericName" is required; "Categories" needs the Emulator sub-category.

At least openSUSE's checks are pretty strict about those. Fedora not so much but doesn't hurt either.