### PR TITLE
Ignore the build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build
 bin
 obj
 *.depend


### PR DESCRIPTION
Just a `.gitignore` change to get rid of the `build` directory (created when following the readme instructions) in git status/diff.