### PR TITLE
Add GitHub workflow configurations for continuous integration with Linux and Windows

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -17,11 +17,11 @@ jobs:
       shell: bash
       working-directory: ${{runner.workspace}}
       run: | # Fetch a new version of CMake, because the default is too old.
-           wget -nv https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz \
-           && tar -zxf cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz \
-           && sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list \
-           && sudo apt-get update \
-           && sudo apt-get install gtk+-3.0 libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev
+        wget -nv https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz \
+        && tar -zxf cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz \
+        && sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list \
+        && sudo apt-get update \
+        && sudo apt-get install gtk+-3.0 libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev
     - name: Create build environment
       run: mkdir ${{runner.workspace}}/build
     - name: Configure
@@ -31,8 +31,11 @@ jobs:
     - name: Make
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: make -j$(nproc --all)
+      run: |
+        make -j$(nproc --all) \
+        && mkdir dist \
+        && cp {melonDS,romlist.bin} dist
     - uses: actions/upload-artifact@v1
       with:
         name: melonDS
-        path: ${{runner.workspace}}/build/melonDS
+        path: ${{runner.workspace}}/build/dist

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -31,3 +31,7 @@ jobs:
       shell: bash
       working-directory: ${{runner.workspace}}/build
       run: make -j$(nproc --all)
+    - uses: actions/upload-artifact@v1
+      with:
+        name: melonDS
+        path: ${{runner.workspace}}/build/melonDS

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -19,6 +19,7 @@ jobs:
       run: | # Fetch a new version of CMake, because the default is too old.
            wget -nv https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz \
            && tar -zxf cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz \
+           && sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list \
            && sudo apt-get update \
            && sudo apt-get install gtk+-3.0 libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev
     - name: Create build environment

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -19,6 +19,7 @@ jobs:
       run: | # Fetch a new version of CMake, because the default is too old.
            wget -nv https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz \
            && tar -zxf cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz \
+           && sudo apt-get update \
            && sudo apt-get install gtk+-3.0 libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev
     - name: Create build environment
       run: mkdir ${{runner.workspace}}/build

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -1,6 +1,6 @@
-name: C/C++ CI with CMake
+name: CMake Build (Ubuntu x86-64)
 
-on: [push]
+on: [push, pull_request]
 
 env:
   BUILD_TYPE: Release
@@ -8,9 +8,9 @@ env:
 
 jobs:
   build:
-  
+
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -31,8 +31,9 @@ jobs:
     - name: Make
       run: |
         C:\tools\msys64\usr\bin\bash.exe -lc "export PATH=`"/mingw64/bin:`$PATH`" \
-        && cd melonDS/build && make -j$(nproc --all)"
+        && cd melonDS/build && make -j$(nproc --all) \
+        && ../msys-dist.sh"
     - uses: actions/upload-artifact@v1
       with:
-        name: melonDS.exe
-        path: C:\tools\msys64\home\runneradmin\melonDS\build\melonDS.exe
+        name: melonDS
+        path: C:\tools\msys64\home\runneradmin\melonDS\build\dist

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,34 @@
+name: CMake Build (Windows x86-64)
+
+on: [push, pull_request]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install MSYS2
+      working-directory: ${{runner.workspace}}
+      run: | # Fetch MSYS2 build from XQEmu. Official distribution causes a CI failure due to permission errors.
+        Invoke-WebRequest -Uri "https://github.com/xqemu/ci-environment-msys2/releases/latest/download/msys64.7z" -OutFile "msys64.7z"
+        7z x -y msys64.7z "-oC:\tools\"
+        C:\tools\msys64\usr\bin\bash.exe -lc "pacman -Syuq --noconfirm"
+    - name: Install dependencies
+      run: C:\tools\msys64\usr\bin\bash.exe -lc "pacman -Sq --noconfirm git make mingw-w64-x86_64-{cmake,mesa,SDL2,toolchain}"
+    - name: Create build environment
+      run: |
+        New-Item -ItemType directory -Path ${{runner.workspace}}\melonDS\build
+        Copy-Item -Path ${{runner.workspace}}\melonDS -Destination C:\tools\msys64\home\runneradmin -Recurse
+    - name: Configure
+      run: |
+        C:\tools\msys64\usr\bin\bash.exe -lc "export PATH=`"/mingw64/bin:`$PATH`" \
+        && cd melonDS/build && cmake .. -G 'MSYS Makefiles' -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}"
+    - name: Make
+      run: |
+        C:\tools\msys64\usr\bin\bash.exe -lc "export PATH=`"/mingw64/bin:`$PATH`" \
+        && cd melonDS/build && make -j$(nproc --all)"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -32,3 +32,7 @@ jobs:
       run: |
         C:\tools\msys64\usr\bin\bash.exe -lc "export PATH=`"/mingw64/bin:`$PATH`" \
         && cd melonDS/build && make -j$(nproc --all)"
+    - uses: actions/upload-artifact@v1
+      with:
+        name: melonDS.exe
+        path: C:\tools\msys64\home\runneradmin\melonDS\build\melonDS.exe

--- a/.github/workflows/ccppcmake.yml
+++ b/.github/workflows/ccppcmake.yml
@@ -1,0 +1,32 @@
+name: C/C++ CI with CMake
+
+on: [push]
+
+env:
+  BUILD_TYPE: Release
+  CMAKE_VERSION: 3.15.2
+
+jobs:
+  build:
+  
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install dependencies
+      shell: bash
+      working-directory: ${{runner.workspace}}
+      run: | # Fetch a new version of CMake, because the default is too old.
+           wget -nv https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz \
+           && tar -zxf cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz \
+           && sudo apt-get install gtk+-3.0 libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev
+    - name: Create build environment
+      run: mkdir ${{runner.workspace}}/build
+    - name: Configure
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: ${{runner.workspace}}/cmake-$CMAKE_VERSION-Linux-x86_64/bin/cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+    - name: Make
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: make -j$(nproc --all)


### PR DESCRIPTION
This enables continuous integration with GitHub Actions, allowing developers to see if their commits/PRs are breaking the build.
Example run [here](https://github.com/rzumer/melonDS/commit/7027813cb268c8b168a2c6ac7e871761f02a4435/checks?check_suite_id=353617464).

Both Linux and Windows are included, and the compiled binaries are exported with shared libraries and `romlist.bin`.

Closes #540, closes #301 and closes #387.