### PR TITLE
BUGFIX: Fixed misspelled 'float' from original 'floor'

### DIFF
--- a/src/libui_sdl/main.cpp
+++ b/src/libui_sdl/main.cpp
@@ -587,7 +587,7 @@ void AudioCallback(void* data, Uint8* stream, int len)
 
     float f_len_in = (len * 32823.6328125) / (float)AudioFreq;
     f_len_in += AudioSampleFrac;
-    int len_in = (int)floor(f_len_in);
+    int len_in = (int)float(f_len_in);
     AudioSampleFrac = f_len_in - len_in;
 
     s16 buf_in[1024*2];


### PR DESCRIPTION
Fixed misspelled 'float' from original 'floor' in 'src\libui_sdl\main.cpp' line 590.
The code couldn't compile before this bugfix.

Tool used: CodeBlocks.