### PR TITLE
Made randomizing the MAC address optional.

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -34,6 +34,8 @@ int Threaded3D;
 int GL_ScaleFactor;
 int GL_Antialias;
 
+int RandomizeMAC;
+
 ConfigEntry ConfigFile[] =
 {
     {"3DRenderer", 0, &_3DRenderer, 1, NULL, 0},
@@ -41,6 +43,8 @@ ConfigEntry ConfigFile[] =
 
     {"GL_ScaleFactor", 0, &GL_ScaleFactor, 1, NULL, 0},
     {"GL_Antialias", 0, &GL_Antialias, 0, NULL, 0},
+
+    {"RandomizeMAC", 0, &RandomizeMAC, 0, NULL, 0},
 
     {"", -1, NULL, 0, NULL, 0}
 };

--- a/src/Config.h
+++ b/src/Config.h
@@ -46,6 +46,8 @@ extern int Threaded3D;
 extern int GL_ScaleFactor;
 extern int GL_Antialias;
 
+extern int RandomizeMAC;
+
 }
 
 #endif // CONFIG_H

--- a/src/SPI.cpp
+++ b/src/SPI.cpp
@@ -165,14 +165,22 @@ void Reset()
 
     *(u16*)&Firmware[userdata+0x72] = CRC16(&Firmware[userdata], 0x70, 0xFFFF);
 
-    // replace MAC address with random address
-    // TODO: make optional?
+    // set MAC address
     Firmware[0x36] = 0x00;
     Firmware[0x37] = 0x09;
     Firmware[0x38] = 0xBF;
-    Firmware[0x39] = rand()&0xFF;
-    Firmware[0x3A] = rand()&0xFF;
-    Firmware[0x3B] = rand()&0xFF;
+    if (Config::RandomizeMAC)
+    {
+        Firmware[0x39] = rand()&0xFF;
+        Firmware[0x3A] = rand()&0xFF;
+        Firmware[0x3B] = rand()&0xFF;
+    }
+    else
+    {
+        Firmware[0x39] = 0xDC;
+        Firmware[0x3A] = 0xE4;
+        Firmware[0x3B] = 0x13;
+    }
 
     printf("MAC: %02X:%02X:%02X:%02X:%02X:%02X\n",
            Firmware[0x36], Firmware[0x37], Firmware[0x38],

--- a/src/libui_sdl/DlgWifiSettings.cpp
+++ b/src/libui_sdl/DlgWifiSettings.cpp
@@ -49,6 +49,7 @@ uiWindow* win;
 bool haspcap;
 
 uiCheckbox* cbBindAnyAddr;
+uiCheckbox* cbRandomizeMAC;
 
 uiLabel* lbAdapterList;
 uiCombobox* cmAdapterList;
@@ -137,6 +138,7 @@ void OnCancel(uiButton* btn, void* blarg)
 void OnOk(uiButton* btn, void* blarg)
 {
     Config::SocketBindAnyAddr = uiCheckboxChecked(cbBindAnyAddr);
+    Config::RandomizeMAC = uiCheckboxChecked(cbRandomizeMAC);
     Config::DirectLAN = uiCheckboxChecked(cbDirectLAN);
 
     int sel = uiComboboxSelected(cmAdapterList);
@@ -189,6 +191,9 @@ void Open()
 
         cbBindAnyAddr = uiNewCheckbox("Bind socket to any address");
         uiBoxAppend(in_ctrl, uiControl(cbBindAnyAddr), 0);
+
+        cbRandomizeMAC = uiNewCheckbox("Randomize MAC address");
+        uiBoxAppend(in_ctrl, uiControl(cbRandomizeMAC), 0);
     }
 
     {
@@ -240,6 +245,7 @@ void Open()
     }
 
     uiCheckboxSetChecked(cbBindAnyAddr, Config::SocketBindAnyAddr);
+    uiCheckboxSetChecked(cbRandomizeMAC, Config::RandomizeMAC);
 
     int sel = 0;
     for (int i = 0; i < LAN_PCap::NumAdapters; i++)


### PR DESCRIPTION
Fixes Arisotura/melonDS#447

This is my first time working in C++, so I don't know if I've broken any code laws.
I can confirm that this fixes the anti-time travel bug in Pokémon Platinum though.