### PR TITLE
Small tweak to the missing files error message.

### DIFF
--- a/src/libui_sdl/main.cpp
+++ b/src/libui_sdl/main.cpp
@@ -2714,7 +2714,7 @@ int main(int argc, char** argv)
     }
 #else
 	const char* confdir = g_get_user_config_dir();
-	const char* confname = "/melonds";
+	const char* confname = "/melonDS";
 	EmuDirectory = new char[strlen(confdir) + strlen(confname) + 1];
 	strcat(EmuDirectory, confdir);
 	strcat(EmuDirectory, confname);


### PR DESCRIPTION
melonDS wants the files to be placed in melonds, but looks in melonDS. This works for Windows but everywhere else case sensitivity makes them two distinctive paths.