### PR TITLE
Disable CI on non-master branches

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -1,6 +1,12 @@
 name: CMake Build (Ubuntu x86-64)
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 env:
   BUILD_TYPE: Release

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,6 +1,12 @@
 name: CMake Build (Windows x86-64)
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 env:
   BUILD_TYPE: Release


### PR DESCRIPTION
This makes automated builds run only on pushes and pull requests to the master branch.