### PR TITLE
Firmware chooser dialog (support for custom BIOS/FW paths)

### DIFF
--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -149,6 +149,21 @@ bool Running;
 bool RunningGame;
 
 
+char* Bios7Path;
+char* Bios9Path;
+char* FirmwarePath;
+
+void SetFilePaths(char* bios7, char* bios9, char* firmware) {
+    Bios7Path = bios7;
+    Bios9Path = bios9;
+    FirmwarePath = firmware;
+}
+
+char* GetFirmwarePath() {
+    return FirmwarePath;
+}
+
+
 void DivDone(u32 param);
 void SqrtDone(u32 param);
 void RunTimer(u32 tid, s32 cycles);
@@ -399,7 +414,7 @@ void Reset()
     RunningGame = false;
     LastSysClockCycles = 0;
 
-    f = Platform::OpenLocalFile("bios9.bin", "rb");
+    f = Platform::OpenLocalFile(Bios9Path, "rb");
     if (!f)
     {
         printf("ARM9 BIOS not found\n");
@@ -416,7 +431,7 @@ void Reset()
         fclose(f);
     }
 
-    f = Platform::OpenLocalFile("bios7.bin", "rb");
+    f = Platform::OpenLocalFile(Bios7Path, "rb");
     if (!f)
     {
         printf("ARM7 BIOS not found\n");

--- a/src/NDS.h
+++ b/src/NDS.h
@@ -131,6 +131,9 @@ void Stop();
 
 bool DoSavestate(Savestate* file);
 
+void SetFilePaths(char* bios7, char* bios9, char* firmware);
+char* GetFirmwarePath();
+
 void SetARM9RegionTimings(u32 addrstart, u32 addrend, int buswidth, int nonseq, int seq);
 void SetARM7RegionTimings(u32 addrstart, u32 addrend, int buswidth, int nonseq, int seq);
 

--- a/src/SPI.cpp
+++ b/src/SPI.cpp
@@ -90,10 +90,10 @@ void Reset()
     if (Firmware) delete[] Firmware;
     Firmware = NULL;
 
-    FILE* f = Platform::OpenLocalFile("firmware.bin", "rb");
+    FILE* f = Platform::OpenLocalFile(NDS::GetFirmwarePath(), "rb");
     if (!f)
     {
-        printf("firmware.bin not found\n");
+        printf("SPI Flash firmware not found\n");
 
         // TODO: generate default firmware
         return;
@@ -325,7 +325,7 @@ void Write(u8 val, u32 hold)
 
     if (!hold && (CurCmd == 0x02 || CurCmd == 0x0A))
     {
-        FILE* f = Platform::OpenLocalFile("firmware.bin", "r+b");
+        FILE* f = Platform::OpenLocalFile(NDS::GetFirmwarePath(), "r+b");
         if (f)
         {
             u32 cutoff = 0x7FA00 & FirmwareMask;

--- a/src/libui_sdl/CMakeLists.txt
+++ b/src/libui_sdl/CMakeLists.txt
@@ -7,6 +7,7 @@ SET(SOURCES_LIBUI
 	LAN_Socket.cpp
 	LAN_PCap.cpp
 	DlgAudioSettings.cpp
+	DlgFirmwareDumps.cpp
 	DlgEmuSettings.cpp
 	DlgInputConfig.cpp
 	DlgVideoSettings.cpp

--- a/src/libui_sdl/DlgFirmwareDumps.cpp
+++ b/src/libui_sdl/DlgFirmwareDumps.cpp
@@ -120,12 +120,13 @@ void createEntry(int idx, const char* labelTxt, uiGrid* grid, uiEntry** entry, v
     
     uiBox* box = uiNewHorizontalBox();
     *entry = uiNewEntry();
+    uiControlSetMinSize(uiControl(*entry), 300, 0);
     uiBoxAppend(box, uiControl(*entry), 1);
     uiButton* browse = uiNewButton("...");
     uiButtonOnClicked(browse, callback, NULL);
     uiBoxAppend(box, uiControl(browse), 0);
-    uiGridAppend(grid, uiControl(box), 1, idx, 5, 1, 1, uiAlignFill, 1, uiAlignCenter);
-    uiControlSetMinSize(uiControl(box), 240, 1);
+    
+    uiGridAppend(grid, uiControl(box), 1, idx, 1, 1, 1, uiAlignFill, 1, uiAlignCenter);
 }
 
 void Open()
@@ -137,7 +138,7 @@ void Open()
     }
 
     opened = true;
-    win = uiNewWindow("Firmware files - melonDS", 800, 100, 0, 0, 1);
+    win = uiNewWindow("Firmware dumps - melonDS", 800, 100, 0, 0, 0);
     uiWindowSetMargined(win, 1);
     uiWindowOnClosing(win, OnCloseWindow, NULL);
 
@@ -152,12 +153,12 @@ void Open()
 
         uiGroup* ds = uiNewGroup("DS/DS Lite");
         uiBoxAppend(in_ctrl, uiControl(ds), 1);
-        
+
         uiGrid* ds_grid = uiNewGrid();
         uiGroupSetChild(ds, uiControl(ds_grid));
         createEntry(0, "ARM7 BIOS ROM (bios7.bin)", ds_grid, &txBios7Path, OnBrowseBios7);
         createEntry(1, "ARM9 BIOS ROM (bios9.bin)", ds_grid, &txBios9Path, OnBrowseBios9);
-        createEntry(2, "SPI Flash (firmware.bin from a DS/DS Lite)\nDSi firmware won't work.", ds_grid, &txFirmwarePath, OnBrowseFirmware);
+        createEntry(2, "SPI Flash (firmware.bin from a DS but not from a DSi)", ds_grid, &txFirmwarePath, OnBrowseFirmware);
 
 
         char helptext[512];

--- a/src/libui_sdl/DlgFirmwareDumps.cpp
+++ b/src/libui_sdl/DlgFirmwareDumps.cpp
@@ -61,7 +61,7 @@ int OnCloseWindow(uiWindow* window, void* blarg)
 void BrowsePath(uiEntry* path, uiButton* btn, void* blarg)
 {
     const char* allowed = 
-        "Any allowed file|*.bin;*.BIN;*.rom;*.ROM|"
+        "Supported files|*.bin;*.BIN;*.rom;*.ROM|"
         "BIN file (*.bin)|*.bin;*.BIN|"
         "ROM file (*.rom)|.*rom;.*ROM|"
         "Any file|*.*";

--- a/src/libui_sdl/DlgFirmwareDumps.cpp
+++ b/src/libui_sdl/DlgFirmwareDumps.cpp
@@ -1,0 +1,211 @@
+/*
+    Copyright 2016-2020 Arisotura
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "libui/ui.h"
+
+#include "../types.h"
+#include "PlatformConfig.h"
+
+#include "DlgFirmwareDumps.h"
+
+
+
+namespace DlgFirmwareDumps
+{
+
+bool opened;
+uiWindow* win;
+
+uiEntry* txBios7Path;
+uiEntry* txBios9Path;
+uiEntry* txFirmwarePath;
+
+char oldBios7[sizeof(Config::Bios7Path)];
+char oldBios9[sizeof(Config::Bios9Path)];
+char oldFirmware[sizeof(Config::FirmwarePath)];
+
+void RevertSettings()
+{
+    strncpy(Config::Bios7Path, oldBios7, 511);
+    strncpy(Config::Bios9Path, oldBios9, 511);
+    strncpy(Config::FirmwarePath, oldFirmware, 511);
+}
+
+
+int OnCloseWindow(uiWindow* window, void* blarg)
+{
+    RevertSettings();
+    opened = false;
+    return 1;
+}
+
+void BrowsePath(uiEntry* path, uiButton* btn, void* blarg)
+{
+    const char* allowed = 
+        "Any allowed file|*.bin;*.BIN;*.rom;*.ROM|"
+        "BIN file (*.bin)|*.bin;*.BIN|"
+        "ROM file (*.rom)|.*rom;.*ROM|"
+        "Any file|*.*";
+    char* file = uiOpenFile(win, allowed, NULL);
+    if (!file)
+    {
+        return;
+    }
+
+    uiEntrySetText(path, file);
+    uiFreeText(file);
+}
+
+void OnBrowseBios7(uiButton *btn, void* blarg) { BrowsePath(txBios7Path, btn, blarg); }
+void OnBrowseBios9(uiButton *btn, void* blarg) { BrowsePath(txBios9Path, btn, blarg); }
+void OnBrowseFirmware(uiButton *btn, void* blarg) { BrowsePath(txFirmwarePath, btn, blarg); }
+
+void OnCancel(uiButton* btn, void* blarg)
+{
+    RevertSettings();
+
+    uiControlDestroy(uiControl(win));
+    opened = false;
+}
+void OnRestore(uiButton* btn, void* blarg)
+{
+    uiEntrySetText(txBios7Path, "bios7.bin");
+    uiEntrySetText(txBios9Path, "bios9.bin");
+    uiEntrySetText(txFirmwarePath, "firmware.bin");
+    opened = false;
+}
+void OnOk(uiButton* btn, void* blarg)
+{
+    char* bios7 = uiEntryText(txBios7Path);
+    strncpy(Config::Bios7Path, bios7, 511);
+    
+    char* bios9 = uiEntryText(txBios9Path);
+    strncpy(Config::Bios9Path, bios9, 511);
+    
+    char* firmware = uiEntryText(txFirmwarePath);
+    strncpy(Config::FirmwarePath, firmware, 511);
+    
+    uiFreeText(bios7);
+    uiFreeText(bios9);
+    uiFreeText(firmware);
+
+    Config::Save();
+
+    uiControlDestroy(uiControl(win));
+    opened = false;
+}
+
+void createEntry(int idx, const char* labelTxt, uiGrid* grid, uiEntry** entry, void (*callback)(uiButton *b, void *data)) {
+    uiLabel* label = uiNewLabel(labelTxt);
+    uiGridAppend(grid, uiControl(label), 0, idx, 1, 1, 1, uiAlignStart, 1, uiAlignCenter);
+    
+    uiBox* box = uiNewHorizontalBox();
+    *entry = uiNewEntry();
+    uiBoxAppend(box, uiControl(*entry), 1);
+    uiButton* browse = uiNewButton("...");
+    uiButtonOnClicked(browse, callback, NULL);
+    uiBoxAppend(box, uiControl(browse), 0);
+    uiGridAppend(grid, uiControl(box), 1, idx, 5, 1, 1, uiAlignFill, 1, uiAlignCenter);
+    uiControlSetMinSize(uiControl(box), 240, 1);
+}
+
+void Open()
+{
+    if (opened)
+    {
+        uiControlSetFocus(uiControl(win));
+        return;
+    }
+
+    opened = true;
+    win = uiNewWindow("Firmware files - melonDS", 800, 100, 0, 0, 1);
+    uiWindowSetMargined(win, 1);
+    uiWindowOnClosing(win, OnCloseWindow, NULL);
+
+    uiBox* top = uiNewVerticalBox();
+    uiWindowSetChild(win, uiControl(top));
+    uiBoxSetPadded(top, 1);
+    
+    {
+        uiBox* in_ctrl = uiNewVerticalBox();
+        uiBoxAppend(top, uiControl(in_ctrl), 0);
+        uiBoxSetPadded(in_ctrl, 1);
+
+        uiGroup* ds = uiNewGroup("DS/DS Lite");
+        uiBoxAppend(in_ctrl, uiControl(ds), 1);
+        
+        uiGrid* ds_grid = uiNewGrid();
+        uiGroupSetChild(ds, uiControl(ds_grid));
+        createEntry(0, "ARM7 BIOS ROM (bios7.bin)", ds_grid, &txBios7Path, OnBrowseBios7);
+        createEntry(1, "ARM9 BIOS ROM (bios9.bin)", ds_grid, &txBios9Path, OnBrowseBios9);
+        createEntry(2, "SPI Flash (firmware.bin from a DS/DS Lite)\nDSi firmware won't work.", ds_grid, &txFirmwarePath, OnBrowseFirmware);
+
+
+        char helptext[512];
+        sprintf(helptext,
+        "NOTE: you can insert the file name without a path; the file will be searched in the current directory and in the config path.");
+        uiLabel* help_label = uiNewLabel(helptext);
+        uiBoxAppend(in_ctrl, uiControl(help_label), 0);
+    }
+
+    {
+        uiBox* in_ctrl = uiNewHorizontalBox();
+        uiBoxSetPadded(in_ctrl, 1);
+        uiBoxAppend(top, uiControl(in_ctrl), 0);
+
+        uiLabel* dummy = uiNewLabel("");
+        uiBoxAppend(in_ctrl, uiControl(dummy), 1);
+
+
+        uiButton* btnrestore = uiNewButton("Restore defaults");
+        uiButtonOnClicked(btnrestore, OnRestore, NULL);
+        uiBoxAppend(in_ctrl, uiControl(btnrestore), 0);
+
+        uiButton* btncancel = uiNewButton("Cancel");
+        uiButtonOnClicked(btncancel, OnCancel, NULL);
+        uiBoxAppend(in_ctrl, uiControl(btncancel), 0);
+
+        uiButton* btnok = uiNewButton("Ok");
+        uiButtonOnClicked(btnok, OnOk, NULL);
+        uiBoxAppend(in_ctrl, uiControl(btnok), 0);
+    }
+
+    strncpy(oldBios7, Config::Bios7Path, 511);
+    strncpy(oldBios9, Config::Bios9Path, 511);
+    strncpy(oldFirmware, Config::FirmwarePath, 511);
+
+    uiEntrySetText(txBios7Path, Config::Bios7Path);
+    uiEntrySetText(txBios9Path, Config::Bios9Path);
+    uiEntrySetText(txFirmwarePath, Config::FirmwarePath);
+
+    uiControlShow(uiControl(win));
+}
+
+void Close()
+{
+    if (!opened) return;
+    uiControlDestroy(uiControl(win));
+    opened = false;
+}
+
+}
+

--- a/src/libui_sdl/DlgFirmwareDumps.h
+++ b/src/libui_sdl/DlgFirmwareDumps.h
@@ -1,0 +1,31 @@
+/*
+    Copyright 2016-2020 Arisotura
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#ifndef DLGFIRMWAREDUMPS_H
+#define DLGFIRMWAREDUMPS_H
+
+namespace DlgFirmwareDumps
+{
+
+void Open();
+void Close();
+
+}
+
+#endif // DLGFIRMWAREDUMPS_H
+

--- a/src/libui_sdl/PlatformConfig.cpp
+++ b/src/libui_sdl/PlatformConfig.cpp
@@ -64,6 +64,9 @@ char MicWavPath[512];
 
 char LastROMFolder[512];
 
+char Bios7Path[512];
+char Bios9Path[512];
+char FirmwarePath[512];
 
 ConfigEntry PlatformConfigFile[] =
 {
@@ -144,6 +147,10 @@ ConfigEntry PlatformConfigFile[] =
     {"MicWavPath", 1, MicWavPath, 0, "", 511},
 
     {"LastROMFolder", 1, LastROMFolder, 0, "", 511},
+
+    {"Bios7Path", 1, Bios7Path, 0, "bios7.bin", 511},
+    {"BiosPath", 1, Bios9Path, 0, "bios9.bin", 511},
+    {"FirmwarePath", 1, FirmwarePath, 0, "firmware.bin", 511},
 
     {"", -1, NULL, 0, NULL, 0}
 };

--- a/src/libui_sdl/PlatformConfig.h
+++ b/src/libui_sdl/PlatformConfig.h
@@ -77,6 +77,10 @@ extern char MicWavPath[512];
 
 extern char LastROMFolder[512];
 
+extern char Bios7Path[512];
+extern char Bios9Path[512];
+extern char FirmwarePath[512];
+
 }
 
 #endif // PLATFORMCONFIG_H


### PR DESCRIPTION
This PR adds the ability to change the FS paths of the bios7.bin, bios9.bin and firmware.bin files, graphically or by editing the config.
I think that the files could actually be managed in a separate struct, but for now (there are only three files) I do not think that this feature could be useful.
There is a very simple file chooser in the Config->Firmware dumps, that also warns the user that DS/DS Lite emulation requires a DS firmware.bin and not a DSi one. It builds on Windows and on Linux, but the CI has problems with the Windows build, I don't know why.
 
Here are the screenshots from a Linux system.
![FirmwareChooser2](https://user-images.githubusercontent.com/61866965/77853496-adc3e480-71e4-11ea-98fa-9dfcc17271dd.png)
![FirmwareChooser](https://user-images.githubusercontent.com/61866965/77853493-ad2b4e00-71e4-11ea-803d-b423d5337ef3.png)
