### PR TITLE
Accurize "screen sizing" UI text

### DIFF
--- a/src/libui_sdl/main.cpp
+++ b/src/libui_sdl/main.cpp
@@ -2580,7 +2580,7 @@ void CreateMainWindowMenu()
         uiMenuItemOnClicked(MenuItem_ScreenSizing[1], OnSetScreenSizing, (void*)&kScreenSizing[1]);
         MenuItem_ScreenSizing[2] = uiMenuAppendCheckItem(submenu, "Emphasize bottom");
         uiMenuItemOnClicked(MenuItem_ScreenSizing[2], OnSetScreenSizing, (void*)&kScreenSizing[2]);
-        MenuItem_ScreenSizing[3] = uiMenuAppendCheckItem(submenu, "Auto");
+        MenuItem_ScreenSizing[3] = uiMenuAppendCheckItem(submenu, "Emphasize 3D engine");
         uiMenuItemOnClicked(MenuItem_ScreenSizing[3], OnSetScreenSizing, (void*)&kScreenSizing[3]);
 
         uiMenuAppendSubmenu(menu, submenu);


### PR DESCRIPTION
The description is currently imprecise/confusing/misleading. "Auto" (I believe) implies it's been curated. But there any many cases in popular games where it's clearly not chosen the "correct" screen.

Would it be reasonable to label this option _descriptively_, rather than _optimistically_?

> 'auto' mode emphasizes whichever screen is set to the main video engine (the one with 3D). hotkeys for switching between layout modes are planned.

– https://github.com/Arisotura/melonDS/issues/489#issuecomment-511202251  