### PR TITLE
Dirty hack to toggle fullscreen with F11 in gtk & windows

### DIFF
--- a/src/libui_sdl/libui/unix/window.c
+++ b/src/libui_sdl/libui/unix/window.c
@@ -265,10 +265,17 @@ int uiWindowFullscreen(uiWindow *w)
 void uiWindowSetFullscreen(uiWindow *w, int fullscreen)
 {
 	w->fullscreen = fullscreen;
-	if (w->fullscreen)
+	if (w->fullscreen) {
+		if(w->menubar) {
+			gtk_widget_hide(w->menubar);
+		}
 		gtk_window_fullscreen(w->window);
-	else
+	} else {
+		if(w->menubar) {
+			gtk_widget_show(w->menubar);
+		}
 		gtk_window_unfullscreen(w->window);
+	}
 }
 
 void uiWindowOnContentSizeChanged(uiWindow *w, void (*f)(uiWindow *, void *), void *data)

--- a/src/libui_sdl/libui/windows/window.cpp
+++ b/src/libui_sdl/libui/windows/window.cpp
@@ -443,6 +443,11 @@ void uiWindowSetFullscreen(uiWindow *w, int fullscreen)
 	w->fullscreen = fullscreen;
 	w->changingSize = TRUE;
 	if (w->fullscreen) {
+		if(w->menubar) { // HACK
+			w->hasMenubar = FALSE;
+			SetMenu(w->hwnd, NULL);
+		}
+		
 		ZeroMemory(&(w->fsPrevPlacement), sizeof (WINDOWPLACEMENT));
 		w->fsPrevPlacement.length = sizeof (WINDOWPLACEMENT);
 		if (GetWindowPlacement(w->hwnd, &(w->fsPrevPlacement)) == 0)
@@ -455,6 +460,11 @@ void uiWindowSetFullscreen(uiWindow *w, int fullscreen)
 			SWP_FRAMECHANGED | SWP_NOOWNERZORDER) == 0)
 			logLastError(L"error making window fullscreen");
 	} else {
+		if(w->menubar) { // HACK
+			w->hasMenubar = TRUE;
+			SetMenu(w->hwnd, w->menubar);
+		}
+		
 		if (!w->borderless)		// keep borderless until that is turned off
 			setStyle(w->hwnd, getStyle(w->hwnd) | WS_OVERLAPPEDWINDOW);
 		if (SetWindowPlacement(w->hwnd, &(w->fsPrevPlacement)) == 0)

--- a/src/libui_sdl/main.cpp
+++ b/src/libui_sdl/main.cpp
@@ -200,7 +200,10 @@ void CreateMainWindow(bool opengl);
 void DestroyMainWindow();
 void RecreateMainWindow(bool opengl);
 
-
+void ToggleFullscreen()
+{
+	uiWindowSetFullscreen(MainWindow, !uiWindowFullscreen(MainWindow));
+}
 
 bool GLScreen_InitShader(GLuint* shader, const char* fs)
 {
@@ -1329,6 +1332,10 @@ int OnAreaKeyEvent(uiAreaHandler* handler, uiArea* area, uiAreaKeyEvent* evt)
         {
             if (evt->Modifiers == 0x0) UndoStateLoad();
         }
+		else if (evt->Scancode == 0x57) // F11
+		{
+			ToggleFullscreen();
+		}
 
         for (int i = 0; i < 12; i++)
             if (EventMatchesKey(evt, Config::KeyMapping[i], false))


### PR DESCRIPTION
Dirty hack to make F11 toggle fullscreen in the windows and gtk builds, based on https://github.com/Arisotura/melonDS/issues/237#issuecomment-436489499. I just wanted to throw this up on github in case anyone else compiling the gtk build wanted a hardcoded f11 fullscreen toggle. Feel free to close.

See: https://github.com/Arisotura/melonDS/issues/237