### PR TITLE
Add hotkey to switch screen emphasis

### DIFF
--- a/src/libui_sdl/DlgInputConfig.cpp
+++ b/src/libui_sdl/DlgInputConfig.cpp
@@ -73,7 +73,8 @@ char hotkeylabels[HK_MAX][32] =
     "Fast forward:",
     "Fast forward (toggle):",
     "Decrease sunlight (Boktai):",
-    "Increase sunlight (Boktai):"
+    "Increase sunlight (Boktai):",
+    "Switch Screen Emphasis"
 };
 
 int openedmask;

--- a/src/libui_sdl/PlatformConfig.cpp
+++ b/src/libui_sdl/PlatformConfig.cpp
@@ -101,6 +101,7 @@ ConfigEntry PlatformConfigFile[] =
     {"HKKey_FastForwardToggle",   0, &HKKeyMapping[HK_FastForwardToggle],     -1, NULL, 0},
     {"HKKey_SolarSensorDecrease", 0, &HKKeyMapping[HK_SolarSensorDecrease], 0x4B, NULL, 0},
     {"HKKey_SolarSensorIncrease", 0, &HKKeyMapping[HK_SolarSensorIncrease], 0x4D, NULL, 0},
+    {"HKKey_SwitchEmphasis",      0, &HKKeyMapping[HK_SwitchEmphasis],        -1, NULL, 0},
 
     {"HKJoy_Lid",                 0, &HKJoyMapping[HK_Lid],                 -1, NULL, 0},
     {"HKJoy_Mic",                 0, &HKJoyMapping[HK_Mic],                 -1, NULL, 0},
@@ -110,6 +111,7 @@ ConfigEntry PlatformConfigFile[] =
     {"HKJoy_FastForwardToggle",   0, &HKJoyMapping[HK_FastForwardToggle],   -1, NULL, 0},
     {"HKJoy_SolarSensorDecrease", 0, &HKJoyMapping[HK_SolarSensorDecrease], -1, NULL, 0},
     {"HKJoy_SolarSensorIncrease", 0, &HKJoyMapping[HK_SolarSensorIncrease], -1, NULL, 0},
+    {"HKJoy_SwitchEmphasis",      0, &HKJoyMapping[HK_SwitchEmphasis],      -1, NULL, 0},
 
     {"JoystickID", 0, &JoystickID, 0, NULL, 0},
 

--- a/src/libui_sdl/PlatformConfig.h
+++ b/src/libui_sdl/PlatformConfig.h
@@ -31,6 +31,7 @@ enum
     HK_FastForwardToggle,
     HK_SolarSensorDecrease,
     HK_SolarSensorIncrease,
+    HK_SwitchEmphasis,
     HK_MAX
 };
 

--- a/src/libui_sdl/main.cpp
+++ b/src/libui_sdl/main.cpp
@@ -184,6 +184,7 @@ u32 MicBufferReadPos, MicBufferWritePos;
 u32 MicWavLength;
 s16* MicWavBuffer;
 
+void OnSetScreenSizing(uiMenuItem* item, uiWindow* window, void* param);
 void SetupScreenRects(int width, int height);
 
 void TogglePause(void* blarg);
@@ -958,6 +959,11 @@ int EmuThreadFunc(void* burp)
 
         if (HotkeyPressed(HK_Pause)) uiQueueMain(TogglePause, NULL);
         if (HotkeyPressed(HK_Reset)) uiQueueMain(Reset, NULL);
+
+        if (HotkeyPressed(HK_SwitchEmphasis)) {
+            ScreenSizing = ScreenSizing == 1 ? 2 : 1;
+            OnSetScreenSizing(NULL, NULL, &ScreenSizing);
+        }
 
         if (GBACart::CartInserted && GBACart::HasSolarSensor)
         {


### PR DESCRIPTION
Just throwing this up on github in case others were looking for a way to add a hotkey to switch screen emphasis between bottom/top until melonDS's QT ui is finished.