### PR TITLE
Hide mouse when not in use

### DIFF
--- a/src/libui_sdl/libui/darwin/window.m
+++ b/src/libui_sdl/libui/darwin/window.m
@@ -271,6 +271,11 @@ void uiWindowSetContentSize(uiWindow *w, int width, int height)
 	w->suppressSizeChanged = NO;
 }
 
+void uiWindowSetMouseCursorVisibility(uiWindow *w, int visible)
+{
+	// TODO
+}
+
 int uiWindowFullscreen(uiWindow *w)
 {
 	return w->fullscreen;

--- a/src/libui_sdl/libui/ui.h
+++ b/src/libui_sdl/libui/ui.h
@@ -117,6 +117,7 @@ _UI_EXTERN void uiWindowSetMinimized(uiWindow *w, int minimized);
 _UI_EXTERN int uiWindowMaximized(uiWindow *w);
 _UI_EXTERN void uiWindowSetMaximized(uiWindow *w, int maximized);
 _UI_EXTERN int uiWindowFullscreen(uiWindow *w);
+_UI_EXTERN void uiWindowSetMouseCursorVisibility(uiWindow *w, int visible);
 _UI_EXTERN void uiWindowSetFullscreen(uiWindow *w, int fullscreen);
 _UI_EXTERN int uiWindowBorderless(uiWindow *w);
 _UI_EXTERN void uiWindowSetBorderless(uiWindow *w, int borderless);

--- a/src/libui_sdl/libui/unix/window.c
+++ b/src/libui_sdl/libui/unix/window.c
@@ -253,6 +253,21 @@ void uiWindowSetMaximized(uiWindow *w, int maximized)
         gtk_window_unmaximize(w->window);
 }
 
+void uiWindowSetMouseCursorVisibility(uiWindow *w, int visible)
+{
+	static int mouse_cursor_is_visible = 1;
+	if (mouse_cursor_is_visible == visible)
+		return;
+
+	mouse_cursor_is_visible = visible;
+	GdkCursor *cursor = NULL;
+	if (!visible) {
+		GdkDisplay *display = gtk_widget_get_display (w->widget);
+		cursor = gdk_cursor_new_from_name (display, "none");
+	}
+	GdkWindow *window = gtk_widget_get_window (w->widget);
+	gdk_window_set_cursor (window, cursor);
+}
 
 int uiWindowFullscreen(uiWindow *w)
 {

--- a/src/libui_sdl/libui/windows/window.cpp
+++ b/src/libui_sdl/libui/windows/window.cpp
@@ -426,6 +426,10 @@ void uiWindowSetMaximized(uiWindow *w, int maximized)
         ShowWindow(w->hwnd, SW_RESTORE);
 }
 
+void uiWindowSetMouseCursorVisibility(uiWindow *w, int visible)
+{
+	// TODO
+}
 
 int uiWindowFullscreen(uiWindow *w)
 {

--- a/src/libui_sdl/main.cpp
+++ b/src/libui_sdl/main.cpp
@@ -814,6 +814,11 @@ bool JoystickButtonDown(int val)
     return false;
 }
 
+void SetMouseCursorVisibility(int visible)
+{
+    uiWindowSetMouseCursorVisibility(MainWindow, visible);
+}
+
 void ProcessInput()
 {
     SDL_JoystickUpdate();
@@ -948,6 +953,9 @@ int EmuThreadFunc(void* burp)
     while (EmuRunning != 0)
     {
         ProcessInput();
+        if ((KeyInputMask & JoyInputMask) != 0xFFF) {
+            SetMouseCursorVisibility(0);
+        }
 
         if (HotkeyPressed(HK_FastForwardToggle))
         {
@@ -1209,6 +1217,8 @@ void OnAreaDraw(uiAreaHandler* handler, uiArea* area, uiAreaDrawParams* params)
 
 void OnAreaMouseEvent(uiAreaHandler* handler, uiArea* area, uiAreaMouseEvent* evt)
 {
+    SetMouseCursorVisibility(1);
+
     int x = (int)evt->X;
     int y = (int)evt->Y;
 


### PR DESCRIPTION
Another QoL hack that hides the cursor when it is not in use (only implemented the gtk part though). I found the cursor to get in the way after use when switching between different DS window emphasis.