### PR TITLE
Update Ubuntu version used for CI

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Ubuntu 20.04 is supported "as a preview"
and may have to be replaced in the future,
but 18.04's Qt package is too old to build.