### PR TITLE
Add libslipr dependency to CMakeLists and pipelines

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -1,12 +1,7 @@
 name: CMake Build (Ubuntu x86-64)
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  [push, pull_request]
 
 env:
   BUILD_TYPE: Release
@@ -15,7 +10,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1
@@ -23,17 +18,14 @@ jobs:
       shell: bash
       working-directory: ${{runner.workspace}}
       run: | # Fetch a new version of CMake, because the default is too old.
-        wget -nv https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz \
-        && tar -zxf cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz \
-        && sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list \
-        && sudo apt-get update \
-        && sudo apt-get install gtk+-3.0 libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev qt5-default
+        sudo apt-get update \
+        && sudo apt-get install cmake gtk+-3.0 libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev qt5-default libslirp-dev libc6-dev
     - name: Create build environment
       run: mkdir ${{runner.workspace}}/build
     - name: Configure
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: ${{runner.workspace}}/cmake-$CMAKE_VERSION-Linux-x86_64/bin/cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
     - name: Make
       shell: bash
       working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,12 +1,7 @@
 name: CMake Build (Windows x86-64)
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+  [push, pull_request]
 
 env:
   BUILD_TYPE: Release
@@ -21,11 +16,10 @@ jobs:
     - name: Install MSYS2
       working-directory: ${{runner.workspace}}
       run: | # Fetch MSYS2 build from XQEmu. Official distribution causes a CI failure due to permission errors.
-        Invoke-WebRequest -Uri "https://github.com/xqemu/ci-environment-msys2/releases/latest/download/msys64.7z" -OutFile "msys64.7z"
-        7z x -y msys64.7z "-oC:\tools\"
+        choco install msys2
         C:\tools\msys64\usr\bin\bash.exe -lc "pacman -Syuq --noconfirm"
     - name: Install dependencies
-      run: C:\tools\msys64\usr\bin\bash.exe -lc "pacman -Sq --noconfirm git make mingw-w64-x86_64-{cmake,mesa,SDL2,qt5-static,toolchain}"
+      run: C:\tools\msys64\usr\bin\bash.exe -lc "pacman -Sq --noconfirm git make mingw-w64-x86_64-{cmake,SDL2,qt5-static,toolchain,libslirp}"
     - name: Create build environment
       run: |
         New-Item -ItemType directory -Path ${{runner.workspace}}\melonDS\build

--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -1,41 +1,41 @@
 project(qt_sdl)
 
 SET(SOURCES_QT_SDL
-	main.cpp
-	main_shaders.h
-	EmuSettingsDialog.cpp
-	InputConfigDialog.cpp
-	VideoSettingsDialog.cpp
-	AudioSettingsDialog.cpp
-	WifiSettingsDialog.cpp
-	Input.cpp
-	LAN_PCap.cpp
-	LAN_Socket.cpp
-	OSD.cpp
-	OSD_shaders.h
-	font.h
-	Platform.cpp
-	PlatformConfig.cpp
-	
-	../Util_ROM.cpp
-	../Util_Video.cpp
-	../Util_Audio.cpp
-	../FrontendUtil.h
-	../mic_blow.h
-	
-	../../../melon.qrc
+    main.cpp
+    main_shaders.h
+    EmuSettingsDialog.cpp
+    InputConfigDialog.cpp
+    VideoSettingsDialog.cpp
+    AudioSettingsDialog.cpp
+    WifiSettingsDialog.cpp
+    Input.cpp
+    LAN_PCap.cpp
+    LAN_Socket.cpp
+    OSD.cpp
+    OSD_shaders.h
+    font.h
+    Platform.cpp
+    PlatformConfig.cpp
+
+    ../Util_ROM.cpp
+    ../Util_Video.cpp
+    ../Util_Audio.cpp
+    ../FrontendUtil.h
+    ../mic_blow.h
+
+    ../../../melon.qrc
 )
 
 if (WIN32)
-	set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> -i <SOURCE> -o <OBJECT>")
+    set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> -i <SOURCE> -o <OBJECT>")
 endif()
 
 if (BUILD_STATIC AND QT5_STATIC_DIR)
-	set(QT5_STATIC_BASE ${QT5_STATIC_DIR}/lib/cmake/Qt5)
-	set(Qt5_DIR ${QT5_STATIC_BASE})
-	set(Qt5Core_DIR ${QT5_STATIC_BASE}Core)
-	set(Qt5Gui_DIR ${QT5_STATIC_BASE}Gui)
-	set(Qt5Widgets_DIR ${QT5_STATIC_BASE}Widgets)
+    set(QT5_STATIC_BASE ${QT5_STATIC_DIR}/lib/cmake/Qt5)
+    set(Qt5_DIR ${QT5_STATIC_BASE})
+    set(Qt5Core_DIR ${QT5_STATIC_BASE}Core)
+    set(Qt5Gui_DIR ${QT5_STATIC_BASE}Gui)
+    set(Qt5Widgets_DIR ${QT5_STATIC_BASE}Widgets)
 endif()
 
 find_package(Qt5 COMPONENTS Core Gui Widgets REQUIRED)
@@ -44,14 +44,19 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 
+find_package(Threads REQUIRED)
+find_package(Iconv REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(SDL2 REQUIRED sdl2)
+pkg_check_modules(SLIRP REQUIRED slirp)
 
 if (WIN32 AND (CMAKE_BUILD_TYPE STREQUAL Release))
-	add_executable(melonDS WIN32 ${SOURCES_QT_SDL})
+    add_executable(melonDS WIN32 ${SOURCES_QT_SDL})
 else()
-	add_executable(melonDS ${SOURCES_QT_SDL})
+    add_executable(melonDS ${SOURCES_QT_SDL})
 endif()
+
+target_link_libraries(melonDS ${CMAKE_THREAD_LIBS_INIT})
 
 target_include_directories(melonDS PRIVATE ${SDL2_INCLUDE_DIRS})
 target_include_directories(melonDS PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
@@ -60,9 +65,9 @@ target_include_directories(melonDS PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../..")
 target_link_libraries(melonDS core)
 
 if (BUILD_STATIC)
-	target_link_libraries(melonDS -static ${SDL2_LIBRARIES})
+    target_link_libraries(melonDS -static ${SDL2_LIBRARIES} ${SLIRP_LIBRARIES})
 else()
-	target_link_libraries(melonDS ${SDL2_LIBRARIES})
+    target_link_libraries(melonDS ${SDL2_LIBRARIES} ${SLIRP_LIBRARIES})
 endif()
 
 if (UNIX)


### PR DESCRIPTION
This fixes both pipelines by adding libslirp both to the CMaleLists.txt dependencies and the github pipelines.

Some things to take into account:
  - I updated the [Ubuntu version to 20.04](https://github.com/actions/virtual-environments/issues/228) because libslirp is not available in 18.04. We could still build it, install it and create a .pc file but I don't see the point
  - I applied @nadiaholmquist [fix of the Windows pipeline](https://github.com/Arisotura/melonDS/commit/acb1eec35d25c3af857cea5762d5ab0f5f24a5b8)
  - I changed the pipeline events to be triggered for every push on every branch and every pull request so we can know if a build is working before a merge on master as most of us will only test it on only one architecture
  - I added the libslirp dependency to the CMakeLists.txt of the frontend/ directory which probably does not make so much sense, however that's where everything seemed to be linked. I can move it somewhere else if you'd like to.