### PR TITLE
Fix Ubuntu x86_64 CI

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -25,7 +25,7 @@ jobs:
       run: | # Fetch a new version of CMake, because the default is too old.
         sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list \
         && sudo apt-get update \
-        && sudo apt-get install cmake libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev qt5-default libslirp-dev
+        && sudo apt-get install cmake libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev qt5-default libslirp0=4.1.0-2ubuntu2.1 libslirp-dev  --allow-downgrades
     - name: Create build environment
       run: mkdir ${{runner.workspace}}/build
     - name: Configure

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ make -j$(nproc --all)
 1. Install [MSYS2](https://www.msys2.org/)
 2. Open the **MSYS2 MinGW 64-bit** terminal
 3. Update the packages using `pacman -Syu` and reopen the terminal if it asks you to
+
+#### Dynamic builds (with DLLs)
 4. Install dependencies: `pacman -S git make mingw-w64-x86_64-{cmake,mesa,SDL2,toolchain,qt5,libslirp}`
 5. Run the following commands
    ```bash
@@ -66,8 +68,21 @@ make -j$(nproc --all)
    make -j$(nproc --all)
    ../msys-dist.sh
    ```
-
 If everything went well, melonDS and the libraries it needs should now be in the `dist` folder.
+
+#### Static builds (without DLLs, standalone executable)
+4. Install dependencies: `pacman -S git make mingw-w64-x86_64-{cmake,mesa,SDL2,toolchain,qt5-static,libslirp}`
+5. Run the following commands
+   ```bash
+   git clone https://github.com/Arisotura/melonDS.git
+   cd melonDS
+   mkdir build
+   cd build
+   cmake .. -G 'MSYS Makefiles' -DBUILD_STATIC=ON -DQT5_STATIC_DIR=/mingw64/qt5-static
+   make -j$(nproc --all)
+   mkdir dist && cp melonDS.exe dist
+   ```
+If everything went well, melonDS should now be in the `dist` folder.
 
 ## TODO LIST
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -36,6 +36,8 @@ char DSiBIOS9Path[1024];
 char DSiBIOS7Path[1024];
 char DSiFirmwarePath[1024];
 char DSiNANDPath[1024];
+int DSiSDEnable;
+char DSiSDPath[1024];
 
 int RandomizeMAC;
 
@@ -57,6 +59,8 @@ ConfigEntry ConfigFile[] =
     {"DSiBIOS7Path", 1, DSiBIOS7Path, 0, "", 1023},
     {"DSiFirmwarePath", 1, DSiFirmwarePath, 0, "", 1023},
     {"DSiNANDPath", 1, DSiNANDPath, 0, "", 1023},
+    {"DSiSDEnable", 0, &DSiSDEnable, 0, NULL, 0},
+    {"DSiSDPath", 1, DSiSDPath, 0, "", 1023},
 
     {"RandomizeMAC", 0, &RandomizeMAC, 0, NULL, 0},
 

--- a/src/Config.h
+++ b/src/Config.h
@@ -50,6 +50,8 @@ extern char DSiBIOS9Path[1024];
 extern char DSiBIOS7Path[1024];
 extern char DSiFirmwarePath[1024];
 extern char DSiNANDPath[1024];
+extern int DSiSDEnable;
+extern char DSiSDPath[1024];
 
 extern int RandomizeMAC;
 

--- a/src/DSi_SD.cpp
+++ b/src/DSi_SD.cpp
@@ -117,13 +117,19 @@ void DSi_SDHost::Reset()
 
     if (Num == 0)
     {
-        // TODO: eventually pull from host filesystem
-        /*DSi_MMCStorage* sd = new DSi_MMCStorage(this, false, "sd.bin");
-        u8 sd_cid[16] = {0xBD, 0x12, 0x34, 0x56, 0x78, 0x03, 0x4D, 0x30, 0x30, 0x46, 0x50, 0x41, 0x00, 0x00, 0x15, 0x00};
-        sd->SetCID(sd_cid);*/
-        DSi_MMCStorage* sd = NULL;
+        DSi_MMCStorage* sd;
+        DSi_MMCStorage* mmc;
 
-        DSi_MMCStorage* mmc = new DSi_MMCStorage(this, true, Config::DSiNANDPath);
+        if (Config::DSiSDEnable)
+        {
+            sd = new DSi_MMCStorage(this, false, Config::DSiSDPath);
+            u8 sd_cid[16] = {0xBD, 0x12, 0x34, 0x56, 0x78, 0x03, 0x4D, 0x30, 0x30, 0x46, 0x50, 0x41, 0x00, 0x00, 0x15, 0x00};
+            sd->SetCID(sd_cid);
+        }
+        else
+            sd = nullptr;
+
+        mmc = new DSi_MMCStorage(this, true, Config::DSiNANDPath);
         mmc->SetCID(DSi::eMMC_CID);
 
         Ports[0] = sd;
@@ -429,14 +435,14 @@ u16 DSi_SDHost::Read(u32 addr)
             if (!Num)
             {
                 if (Ports[0]) // basic check of whether the SD card is inserted
-                    ret |= 0x0030;
+                    ret |= 0x00B0;
                 else
                     ret |= 0x0008;
             }
             else
             {
                 // SDIO wifi is always inserted, I guess
-                ret |= 0x0030;
+                ret |= 0x00B0;
             }
             return ret;
         }

--- a/src/frontend/qt_sdl/EmuSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/EmuSettingsDialog.cpp
@@ -49,6 +49,8 @@ EmuSettingsDialog::EmuSettingsDialog(QWidget* parent) : QDialog(parent), ui(new 
     ui->txtDSiBIOS7Path->setText(Config::DSiBIOS7Path);
     ui->txtDSiFirmwarePath->setText(Config::DSiFirmwarePath);
     ui->txtDSiNANDPath->setText(Config::DSiNANDPath);
+    ui->cbDSiSDEnable->setChecked(Config::DSiSDEnable != 0);
+    ui->txtDSiSDPath->setText(Config::DSiSDPath);
 
     ui->cbxConsoleType->addItem("DS");
     ui->cbxConsoleType->addItem("DSi (experimental)");
@@ -145,6 +147,8 @@ void EmuSettingsDialog::done(int r)
         std::string dsiBios7Path = ui->txtDSiBIOS7Path->text().toStdString();
         std::string dsiFirmwarePath = ui->txtDSiFirmwarePath->text().toStdString();
         std::string dsiNANDPath = ui->txtDSiNANDPath->text().toStdString();
+        int dsiSDEnable = ui->cbDSiSDEnable->isChecked() ? 1:0;
+        std::string dsiSDPath = ui->txtDSiSDPath->text().toStdString();
 
         if (consoleType != Config::ConsoleType
             || directBoot != Config::DirectBoot
@@ -161,7 +165,9 @@ void EmuSettingsDialog::done(int r)
             || strcmp(Config::DSiBIOS9Path, dsiBios9Path.c_str()) != 0
             || strcmp(Config::DSiBIOS7Path, dsiBios7Path.c_str()) != 0
             || strcmp(Config::DSiFirmwarePath, dsiFirmwarePath.c_str()) != 0
-            || strcmp(Config::DSiNANDPath, dsiNANDPath.c_str()) != 0)
+            || strcmp(Config::DSiNANDPath, dsiNANDPath.c_str()) != 0
+            || dsiSDEnable != Config::DSiSDEnable
+            || strcmp(Config::DSiSDPath, dsiSDPath.c_str()) != 0)
         {
             if (RunningSomething
                 && QMessageBox::warning(this, "Reset necessary to apply changes",
@@ -177,6 +183,8 @@ void EmuSettingsDialog::done(int r)
             strncpy(Config::DSiBIOS7Path, dsiBios7Path.c_str(), 1023); Config::DSiBIOS7Path[1023] = '\0';
             strncpy(Config::DSiFirmwarePath, dsiFirmwarePath.c_str(), 1023); Config::DSiFirmwarePath[1023] = '\0';
             strncpy(Config::DSiNANDPath, dsiNANDPath.c_str(), 1023); Config::DSiNANDPath[1023] = '\0';
+            Config::DSiSDEnable = dsiSDEnable;
+            strncpy(Config::DSiSDPath, dsiSDPath.c_str(), 1023); Config::DSiSDPath[1023] = '\0';
 
     #ifdef JIT_ENABLED
             Config::JIT_Enable = jitEnable;
@@ -282,6 +290,18 @@ void EmuSettingsDialog::on_btnDSiNANDBrowse_clicked()
     if (file.isEmpty()) return;
 
     ui->txtDSiNANDPath->setText(file);
+}
+
+void EmuSettingsDialog::on_btnDSiSDBrowse_clicked()
+{
+    QString file = QFileDialog::getOpenFileName(this,
+                                                "Select DSi SD image...",
+                                                EmuDirectory,
+                                                "Image files (*.bin *.rom *.img);;Any file (*.*)");
+
+    if (file.isEmpty()) return;
+
+    ui->txtDSiSDPath->setText(file);
 }
 
 void EmuSettingsDialog::on_chkEnableJIT_toggled()

--- a/src/frontend/qt_sdl/EmuSettingsDialog.h
+++ b/src/frontend/qt_sdl/EmuSettingsDialog.h
@@ -63,6 +63,7 @@ private slots:
     void on_btnDSiBIOS7Browse_clicked();
     void on_btnDSiFirmwareBrowse_clicked();
     void on_btnDSiNANDBrowse_clicked();
+    void on_btnDSiSDBrowse_clicked();
 
     void on_chkEnableJIT_toggled();
 

--- a/src/frontend/qt_sdl/EmuSettingsDialog.ui
+++ b/src/frontend/qt_sdl/EmuSettingsDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>514</width>
-    <height>359</height>
+    <height>407</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -191,59 +191,10 @@
           <string>DSi mode</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="0" column="2">
-           <widget class="QPushButton" name="btnDSiBIOS9Browse">
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_8">
             <property name="text">
-             <string>Browse...</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>DSi ARM9 BIOS:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <widget class="QPushButton" name="btnDSiFirmwareBrowse">
-            <property name="text">
-             <string>Browse...</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLineEdit" name="txtDSiBIOS7Path">
-            <property name="whatsThis">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DSi-mode ARM7 BIOS&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Size should be 64 KB&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QLineEdit" name="txtDSiFirmwarePath">
-            <property name="whatsThis">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DSi-mode firmware (used for DS-mode backwards compatibility)&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Size should be 128 KB&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_6">
-            <property name="text">
-             <string>DSi ARM7 BIOS:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_7">
-            <property name="text">
-             <string>DSi firmware:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QPushButton" name="btnDSiBIOS7Browse">
-            <property name="text">
-             <string>Browse...</string>
+             <string>DSi NAND:</string>
             </property>
            </widget>
           </item>
@@ -260,10 +211,38 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_8">
+          <item row="3" column="2">
+           <widget class="QPushButton" name="btnDSiNANDBrowse">
             <property name="text">
-             <string>DSi NAND:</string>
+             <string>Browse...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="txtDSiFirmwarePath">
+            <property name="whatsThis">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DSi-mode firmware (used for DS-mode backwards compatibility)&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Size should be 128 KB&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="txtDSiBIOS7Path">
+            <property name="whatsThis">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DSi-mode ARM7 BIOS&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Size should be 64 KB&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>DSi ARM9 BIOS:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QPushButton" name="btnDSiBIOS9Browse">
+            <property name="text">
+             <string>Browse...</string>
             </property>
            </widget>
           </item>
@@ -274,8 +253,60 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="2">
-           <widget class="QPushButton" name="btnDSiNANDBrowse">
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_10">
+            <property name="text">
+             <string>DSi SD card:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>DSi ARM7 BIOS:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QPushButton" name="btnDSiBIOS7Browse">
+            <property name="text">
+             <string>Browse...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QPushButton" name="btnDSiFirmwareBrowse">
+            <property name="text">
+             <string>Browse...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>DSi firmware:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0" colspan="3">
+           <widget class="QCheckBox" name="cbDSiSDEnable">
+            <property name="whatsThis">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Simulate a SD card being inserted in the DSi's SD slot. Requires a SD card image.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Enable DSi SD card</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QLineEdit" name="txtDSiSDPath">
+            <property name="whatsThis">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;SD image file for emulating the DSi's SD card&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="2">
+           <widget class="QPushButton" name="btnDSiSDBrowse">
             <property name="text">
              <string>Browse...</string>
             </property>


### PR DESCRIPTION
Temporary fix for the Ubuntu x86_64 CI.
`libslirp-dev` is looking for `libslirp0=4.1.0-2ubuntu2.1`, but apt-get is trying to install a newer version (`libslirp0=4.2.0~4`)