### PR TITLE
Fix Ubuntu x86_64 CI

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -24,8 +24,8 @@ jobs:
       working-directory: ${{runner.workspace}}
       run: | # Fetch a new version of CMake, because the default is too old.
         sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list \
-        && sudo apt-get update \
-        && sudo apt-get install cmake libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev qt5-default libslirp-dev
+        && sudo apt update \
+        && sudo apt install cmake libcurl4-gnutls-dev libpcap0.8-dev libsdl2-dev qt5-default libslirp0=4.1.0-2ubuntu2.1 libslirp-dev --allow-downgrades
     - name: Create build environment
       run: mkdir ${{runner.workspace}}/build
     - name: Configure


### PR DESCRIPTION
Temporary fix for the Ubuntu x86_64 CI.
`libslirp-dev` is looking for `libslirp0=4.1.0-2ubuntu2.1`, but apt is trying to install a newer version (`libslirp0=4.2.0~4`)