### PR TITLE
Fix "Improved polygon splitting" option in GUI

### DIFF
--- a/src/frontend/qt_sdl/VideoSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/VideoSettingsDialog.cpp
@@ -42,6 +42,7 @@ VideoSettingsDialog::VideoSettingsDialog(QWidget* parent) : QDialog(parent), ui(
     oldVSyncInterval = Config::ScreenVSyncInterval;
     oldSoftThreaded = Config::Threaded3D;
     oldGLScale = Config::GL_ScaleFactor;
+    oldGLBetterPolygons = Config::GL_BetterPolygons;
 
     grp3DRenderer = new QButtonGroup(this);
     grp3DRenderer->addButton(ui->rb3DSoftware, 0);
@@ -60,6 +61,8 @@ VideoSettingsDialog::VideoSettingsDialog(QWidget* parent) : QDialog(parent), ui(
         ui->cbxGLResolution->addItem(QString("%1x native (%2x%3)").arg(i).arg(256*i).arg(192*i));
     ui->cbxGLResolution->setCurrentIndex(Config::GL_ScaleFactor-1);
 
+    ui->cbBetterPolygons->setChecked(Config::GL_BetterPolygons != 0);
+
     if (!Config::ScreenVSync)
         ui->sbVSyncInterval->setEnabled(false);
 
@@ -68,12 +71,14 @@ VideoSettingsDialog::VideoSettingsDialog(QWidget* parent) : QDialog(parent), ui(
         ui->cbGLDisplay->setEnabled(true);
         ui->cbSoftwareThreaded->setEnabled(true);
         ui->cbxGLResolution->setEnabled(false);
+        ui->cbBetterPolygons->setEnabled(false);
     }
     else
     {
         ui->cbGLDisplay->setEnabled(false);
         ui->cbSoftwareThreaded->setEnabled(false);
         ui->cbxGLResolution->setEnabled(true);
+        ui->cbBetterPolygons->setEnabled(true);
     }
 }
 
@@ -99,6 +104,7 @@ void VideoSettingsDialog::on_VideoSettingsDialog_rejected()
     Config::ScreenVSyncInterval = oldVSyncInterval;
     Config::Threaded3D = oldSoftThreaded;
     Config::GL_ScaleFactor = oldGLScale;
+    Config::GL_BetterPolygons = oldGLBetterPolygons;
 
     bool new_gl = (Config::ScreenUseGL != 0) || (Config::_3DRenderer != 0);
     emit updateVideoSettings(old_gl != new_gl);
@@ -117,12 +123,14 @@ void VideoSettingsDialog::onChange3DRenderer(int renderer)
         ui->cbGLDisplay->setEnabled(true);
         ui->cbSoftwareThreaded->setEnabled(true);
         ui->cbxGLResolution->setEnabled(false);
+        ui->cbBetterPolygons->setEnabled(false);
     }
     else
     {
         ui->cbGLDisplay->setEnabled(false);
         ui->cbSoftwareThreaded->setEnabled(false);
         ui->cbxGLResolution->setEnabled(true);
+        ui->cbBetterPolygons->setEnabled(true);
     }
 
     bool new_gl = (Config::ScreenUseGL != 0) || (Config::_3DRenderer != 0);

--- a/src/frontend/qt_sdl/VideoSettingsDialog.h
+++ b/src/frontend/qt_sdl/VideoSettingsDialog.h
@@ -79,6 +79,7 @@ private:
     int oldVSyncInterval;
     int oldSoftThreaded;
     int oldGLScale;
+    int oldGLBetterPolygons;
 };
 
 #endif // VIDEOSETTINGSDIALOG_H


### PR DESCRIPTION
This fixes checkbox not reflecting current state of option on dialogue opening, "Cancel" not reverting change and option not being disabled when SW renderer is used.