### PR TITLE
Fix Ubuntu AArch64 CI

### DIFF
--- a/.github/workflows/build-ubuntu-aarch64.yml
+++ b/.github/workflows/build-ubuntu-aarch64.yml
@@ -22,7 +22,6 @@ jobs:
       working-directory: ${{runner.workspace}}
       run: |
         sudo apt update
-        sudo apt full-upgrade
     - name: Install dependencies
       shell: bash
       working-directory: ${{runner.workspace}}


### PR DESCRIPTION
`apt full-upgrade` tries to update the `grub-efi-amd64-signed` package, but it fails to do so, causing the AArch64 CI to fail.
I removed the `sudo apt full-upgrade` line from the workflow file and it works.