### PR TITLE
Add Hybrid Layout

### DIFF
--- a/src/frontend/FrontendUtil.h
+++ b/src/frontend/FrontendUtil.h
@@ -116,6 +116,7 @@ void EnableCheats(bool enable);
 //     0 = natural (top screen above bottom screen always)
 //     1 = vertical
 //     2 = horizontal
+//     3 = hybrid
 // * rotation: angle at which the DS screens are presented: 0/1/2/3 = 0/90/180/270
 // * sizing: how the display size is shared between the two screens
 //     0 = even (both screens get same size)
@@ -140,7 +141,7 @@ const int MaxScreenTransforms = 3;
 
 // get a 2x3 transform matrix for each screen and whether it's a top or bottom screen
 // note: the transform assumes an origin point at the top left of the display,
-// X going left and Y going down
+// X going right and Y going down
 // for each screen the source coordinates should be (0,0) and (256,192)
 // 'out' should point to an array of 6*MaxScreenTransforms floats
 // 'kind' should point to an array of MaxScreenTransforms ints

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -689,12 +689,19 @@ QSize ScreenHandler::screenGetMinSize()
         else
             return QSize(w, h+gap+h);
     }
-    else // horizontal
+    else if (Config::ScreenLayout == 2) // horizontal
     {
         if (isHori)
             return QSize(h+gap+h, w);
         else
             return QSize(w+gap+w, h);
+    }
+    else // hybrid
+    {
+        if (isHori)
+            return QSize(h+gap+h, 3*w +(4*gap) / 3);
+        else
+            return QSize(3*w +(4*gap) / 3, h+gap+h);
     }
 }
 
@@ -1257,9 +1264,9 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
             QMenu* submenu = menu->addMenu("Screen layout");
             grpScreenLayout = new QActionGroup(submenu);
 
-            const char* screenlayout[] = {"Natural", "Vertical", "Horizontal"};
+            const char* screenlayout[] = {"Natural", "Vertical", "Horizontal", "Hybrid"};
 
-            for (int i = 0; i < 3; i++)
+            for (int i = 0; i < 4; i++)
             {
                 actScreenLayout[i] = submenu->addAction(QString(screenlayout[i]));
                 actScreenLayout[i]->setActionGroup(grpScreenLayout);
@@ -2258,12 +2265,19 @@ void MainWindow::onChangeScreenSize()
         else
             resize(QSize(w, h+gap+h) + diff);
     }
-    else // horizontal
+    else if (Config::ScreenLayout == 2) // horizontal
     {
         if (isHori)
             resize(QSize(h+gap+h, w) + diff);
         else
             resize(QSize(w+gap+w, h) + diff);
+    }
+    else // hybrid
+    {
+        if (isHori)
+            return resize(QSize(h+gap+h, 3*w +(4*gap) / 3) + diff);
+        else
+            return resize(QSize(3*w +(4*gap) / 3, h+gap+h) + diff);
     }
 }
 
@@ -2501,7 +2515,7 @@ int main(int argc, char** argv)
     SANITIZE(Config::MicInputType, 0, 3);
     SANITIZE(Config::ScreenRotation, 0, 3);
     SANITIZE(Config::ScreenGap, 0, 500);
-    SANITIZE(Config::ScreenLayout, 0, 2);
+    SANITIZE(Config::ScreenLayout, 0, 3);
     SANITIZE(Config::ScreenSizing, 0, 5);
     SANITIZE(Config::ScreenAspectTop, 0, 4);
     SANITIZE(Config::ScreenAspectBot, 0, 4);

--- a/src/frontend/qt_sdl/main.h
+++ b/src/frontend/qt_sdl/main.h
@@ -305,7 +305,7 @@ public:
     QActionGroup* grpScreenGap;
     QAction* actScreenGap[6];
     QActionGroup* grpScreenLayout;
-    QAction* actScreenLayout[3];
+    QAction* actScreenLayout[4];
     QAction* actScreenSwap;
     QActionGroup* grpScreenSizing;
     QAction* actScreenSizing[6];


### PR DESCRIPTION
Adds 'Hybrid' layout option: draws a large main window in addition to the top and bottom screens.

Features:
- Choosing 'Swap screens' will change the larger window to be the bottom instead of the top.
- Option to touch the hybrid screen when 'Swap screens' is on.

~~Limitations:~~
~~- Currently ignores rotation. It would be a bit more difficult to implement it (personally I don't see how the rotation feature is usefull so I didn't bother).~~
Added support for rotation.

Example screenshot:
![hybrid](https://user-images.githubusercontent.com/71563441/94375814-fcfcba80-011e-11eb-98a8-75dc291d20f1.png)

Closes #484