### PR TITLE
Fix compilation issues on pedantic cpp compilers.

### DIFF
--- a/src/ARMJIT.cpp
+++ b/src/ARMJIT.cpp
@@ -594,7 +594,8 @@ void CompileBlock(ARM* cpu)
     u32 r15 = cpu->R[15];
 
     u32 addressRanges[Config::JIT_MaxBlockSize];
-    u32 addressMasks[Config::JIT_MaxBlockSize] = {0};
+    u32 addressMasks[Config::JIT_MaxBlockSize];
+    memset(addressMasks, 0, Config::JIT_MaxBlockSize * sizeof(u32));
     u32 numAddressRanges = 0;
 
     u32 numLiterals = 0;

--- a/src/ARMJIT_A64/ARMJIT_Compiler.cpp
+++ b/src/ARMJIT_A64/ARMJIT_Compiler.cpp
@@ -68,6 +68,11 @@ void Compiler::A_Comp_MRS()
         MOV(rd, RCPSR);
 }
 
+void UpdateModeTrampoline(ARM* arm, u32 oldmode, u32 newmode)
+{
+    arm->UpdateMode(oldmode, newmode);
+}
+
 void Compiler::A_Comp_MSR()
 {
     Comp_AddCycles_C();
@@ -139,7 +144,7 @@ void Compiler::A_Comp_MSR()
 
             PushRegs(true);
 
-            QuickCallFunction(X3, (void*)&Compiler::UpdateMode);
+            QuickCallFunction(X3, (void*)&UpdateModeTrampoline);
         
             PopRegs(true);
         }
@@ -913,11 +918,6 @@ void Compiler::Comp_AddCycles_CD()
         ADD(RCycles, RCycles, cycles);
     else
         ConstantCycles += cycles;
-}
-
-void Compiler::UpdateMode(ARM* arm, u32 oldmode, u32 newmode)
-{
-    arm->UpdateMode(oldmode, newmode);
 }
 
 }

--- a/src/ARMJIT_A64/ARMJIT_Compiler.cpp
+++ b/src/ARMJIT_A64/ARMJIT_Compiler.cpp
@@ -139,7 +139,7 @@ void Compiler::A_Comp_MSR()
 
             PushRegs(true);
 
-            QuickCallFunction(X3, (void*)&ARM::UpdateMode);
+            QuickCallFunction(X3, (void*)&Compiler::UpdateMode);
         
             PopRegs(true);
         }
@@ -913,6 +913,11 @@ void Compiler::Comp_AddCycles_CD()
         ADD(RCycles, RCycles, cycles);
     else
         ConstantCycles += cycles;
+}
+
+void Compiler::UpdateMode(ARM* arm, u32 oldmode, u32 newmode)
+{
+    arm->UpdateMode(oldmode, newmode);
 }
 
 }

--- a/src/ARMJIT_A64/ARMJIT_Compiler.h
+++ b/src/ARMJIT_A64/ARMJIT_Compiler.h
@@ -187,6 +187,9 @@ public:
     void Comp_RegShiftReg(int op, bool S, Op2& op2, Arm64Gen::ARM64Reg rs);
 
     bool Comp_MemLoadLiteral(int size, bool signExtend, int rd, u32 addr);
+
+    static void UpdateMode(ARM* arm, u32 oldmode, u32 newmode);
+
     enum
     {
         memop_Writeback = 1 << 0,

--- a/src/ARMJIT_A64/ARMJIT_Compiler.h
+++ b/src/ARMJIT_A64/ARMJIT_Compiler.h
@@ -188,8 +188,6 @@ public:
 
     bool Comp_MemLoadLiteral(int size, bool signExtend, int rd, u32 addr);
 
-    static void UpdateMode(ARM* arm, u32 oldmode, u32 newmode);
-
     enum
     {
         memop_Writeback = 1 << 0,

--- a/src/ARMJIT_x64/ARMJIT_Compiler.cpp
+++ b/src/ARMJIT_x64/ARMJIT_Compiler.cpp
@@ -185,7 +185,7 @@ void Compiler::A_Comp_MSR()
             MOV(32, R(ABI_PARAM3), R(RCPSR));
             MOV(32, R(ABI_PARAM2), R(RSCRATCH3));
             MOV(64, R(ABI_PARAM1), R(RCPU));
-            CALL((void*)&ARM::UpdateMode);
+            CALL((void*)&Compiler::UpdateMode);
 
             PopRegs(true);
         }
@@ -895,6 +895,11 @@ void Compiler::Comp_AddCycles_CD()
         ADD(32, MDisp(RCPU, offsetof(ARM, Cycles)), Imm8(cycles));
     else
         ConstantCycles += cycles;
+}
+
+void Compiler::UpdateMode(ARM* arm, u32 oldmode, u32 newmode)
+{
+    arm->UpdateMode(oldmode, newmode);
 }
 
 }

--- a/src/ARMJIT_x64/ARMJIT_Compiler.cpp
+++ b/src/ARMJIT_x64/ARMJIT_Compiler.cpp
@@ -101,6 +101,11 @@ void Compiler::A_Comp_MRS()
         MOV(32, rd, R(RCPSR));
 }
 
+void UpdateModeTrampoline(ARM* arm, u32 oldmode, u32 newmode)
+{
+    arm->UpdateMode(oldmode, newmode);
+}
+
 void Compiler::A_Comp_MSR()
 {
     Comp_AddCycles_C();
@@ -185,7 +190,7 @@ void Compiler::A_Comp_MSR()
             MOV(32, R(ABI_PARAM3), R(RCPSR));
             MOV(32, R(ABI_PARAM2), R(RSCRATCH3));
             MOV(64, R(ABI_PARAM1), R(RCPU));
-            CALL((void*)&Compiler::UpdateMode);
+            CALL((void*)&UpdateModeTrampoline);
 
             PopRegs(true);
         }
@@ -896,10 +901,4 @@ void Compiler::Comp_AddCycles_CD()
     else
         ConstantCycles += cycles;
 }
-
-void Compiler::UpdateMode(ARM* arm, u32 oldmode, u32 newmode)
-{
-    arm->UpdateMode(oldmode, newmode);
-}
-
 }

--- a/src/ARMJIT_x64/ARMJIT_Compiler.h
+++ b/src/ARMJIT_x64/ARMJIT_Compiler.h
@@ -136,8 +136,6 @@ public:
     void T_Comp_BL_LONG_2();
     void T_Comp_BL_Merged();
 
-    static void UpdateMode(ARM* arm, u32 oldmode, u32 newmode);
-
     enum
     {
         memop_Writeback = 1 << 0,

--- a/src/ARMJIT_x64/ARMJIT_Compiler.h
+++ b/src/ARMJIT_x64/ARMJIT_Compiler.h
@@ -136,6 +136,8 @@ public:
     void T_Comp_BL_LONG_2();
     void T_Comp_BL_Merged();
 
+    static void UpdateMode(ARM* arm, u32 oldmode, u32 newmode);
+
     enum
     {
         memop_Writeback = 1 << 0,


### PR DESCRIPTION
I've built melonDS for Android (the libretro core actually), and I found a couple of issues which most pedantic compilers mark as errors.

I also have an Android specific fix to avoid using memfd_create (which is only available from Android 11) in FastMem. If you're interested I'll upstream it, otherwise I'll try to push it into the libretro repository.