### PR TITLE
Input : Treat numpad keys as keypresses

### DIFF
--- a/src/frontend/qt_sdl/Input.cpp
+++ b/src/frontend/qt_sdl/Input.cpp
@@ -98,7 +98,9 @@ int GetEventKeyVal(QKeyEvent* event)
 void KeyPress(QKeyEvent* event)
 {
     int keyHK = GetEventKeyVal(event);
-    int keyKP = keyHK & ~event->modifiers();
+    int keyKP = keyHK;
+    if (event->modifiers() != Qt::KeypadModifier)
+        keyKP &= ~event->modifiers();
 
     for (int i = 0; i < 12; i++)
         if (keyKP == Config::KeyMapping[i])
@@ -112,7 +114,9 @@ void KeyPress(QKeyEvent* event)
 void KeyRelease(QKeyEvent* event)
 {
     int keyHK = GetEventKeyVal(event);
-    int keyKP = keyHK & ~event->modifiers();
+    int keyKP = keyHK;
+    if (event->modifiers() != Qt::KeypadModifier)
+        keyKP &= ~event->modifiers();
 
     for (int i = 0; i < 12; i++)
         if (keyKP == Config::KeyMapping[i])


### PR DESCRIPTION
Typically, modifiers are masked out of keypresses to distinguish
between hotkeys and keypresses. This patch prevents the numpad
modifier from getting masked out in KeyPress() and KeyRelease().

Fixes #740 

Signed-off-by: Madhav Kanbur <abcdjdj@gmail.com>