### PR TITLE
Check for updates from within melonDS

### DIFF
--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -39,7 +39,7 @@ if (BUILD_STATIC AND QT5_STATIC_DIR)
     set(Qt5Widgets_DIR ${QT5_STATIC_BASE}Widgets)
 endif()
 
-find_package(Qt5 COMPONENTS Core Gui Widgets REQUIRED)
+find_package(Qt5 COMPONENTS Core Gui Widgets Network REQUIRED)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
@@ -78,16 +78,16 @@ endif()
 
 if (UNIX)
     option(PORTABLE "Make a portable build that looks for its configuration in the current directory" OFF)
-    target_link_libraries(melonDS dl Qt5::Core Qt5::Gui Qt5::Widgets)
+    target_link_libraries(melonDS dl Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Network)
 elseif (WIN32)
     option(PORTABLE "Make a portable build that looks for its configuration in the current directory" ON)
     target_sources(melonDS PUBLIC "${CMAKE_SOURCE_DIR}/melon.rc")
 
     target_link_libraries(melonDS comctl32 d2d1 dwrite uxtheme ws2_32 iphlpapi gdi32)
     if (BUILD_STATIC)
-        target_link_libraries(melonDS imm32 winmm version setupapi -static Qt5::Core Qt5::Gui Qt5::Widgets z zstd)
+        target_link_libraries(melonDS imm32 winmm version setupapi -static Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Network z zstd)
     else()
-        target_link_libraries(melonDS Qt5::Core Qt5::Gui Qt5::Widgets)
+        target_link_libraries(melonDS Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Network)
     endif()
 endif()
 

--- a/src/frontend/qt_sdl/EmuSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/EmuSettingsDialog.cpp
@@ -59,6 +59,7 @@ EmuSettingsDialog::EmuSettingsDialog(QWidget* parent) : QDialog(parent), ui(new 
     ui->cbxConsoleType->setCurrentIndex(Config::ConsoleType);
 
     ui->chkDirectBoot->setChecked(Config::DirectBoot != 0);
+    ui->chkCheckUpdateOnStart->setChecked(Config::CheckUpdateOnStart != 0);
 
 #ifdef JIT_ENABLED
     ui->chkEnableJIT->setChecked(Config::JIT_Enable != 0);
@@ -135,6 +136,7 @@ void EmuSettingsDialog::done(int r)
 
         int consoleType = ui->cbxConsoleType->currentIndex();
         int directBoot = ui->chkDirectBoot->isChecked() ? 1:0;
+        int checkUpdateOnStart = ui->chkCheckUpdateOnStart->isChecked() ? 1:0;
 
         int jitEnable = ui->chkEnableJIT->isChecked() ? 1:0;
         int jitMaxBlockSize = ui->spnJITMaximumBlockSize->value();
@@ -156,6 +158,7 @@ void EmuSettingsDialog::done(int r)
 
         if (consoleType != Config::ConsoleType
             || directBoot != Config::DirectBoot
+            || checkUpdateOnStart != Config::CheckUpdateOnStart
 #ifdef JIT_ENABLED
             || jitEnable != Config::JIT_Enable
             || jitMaxBlockSize != Config::JIT_MaxBlockSize
@@ -204,6 +207,7 @@ void EmuSettingsDialog::done(int r)
 
             Config::ConsoleType = consoleType;
             Config::DirectBoot = directBoot;
+            Config::CheckUpdateOnStart = checkUpdateOnStart;
 
             Config::Save();
 

--- a/src/frontend/qt_sdl/EmuSettingsDialog.ui
+++ b/src/frontend/qt_sdl/EmuSettingsDialog.ui
@@ -56,7 +56,17 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item row="3" column="1">
+        <widget class="QCheckBox" name="chkCheckUpdateOnStart">
+         <property name="whatsThis">
+          <string>Automatically check for updates on start</string>
+         </property>
+         <property name="text">
+          <string>Check for updates on start</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/frontend/qt_sdl/PlatformConfig.cpp
+++ b/src/frontend/qt_sdl/PlatformConfig.cpp
@@ -59,6 +59,7 @@ int ShowOSD;
 
 int ConsoleType;
 int DirectBoot;
+int CheckUpdateOnStart;
 
 int SocketBindAnyAddr;
 char LANDevice[128];
@@ -153,6 +154,7 @@ ConfigEntry PlatformConfigFile[] =
 
     {"ConsoleType", 0, &ConsoleType, 0, NULL, 0},
     {"DirectBoot", 0, &DirectBoot, 1, NULL, 0},
+    {"CheckUpdateOnStart", 0, &CheckUpdateOnStart, 1, 0},
 
     {"SockBindAnyAddr", 0, &SocketBindAnyAddr, 0, NULL, 0},
     {"LANDevice", 1, LANDevice, 0, "", 127},

--- a/src/frontend/qt_sdl/PlatformConfig.h
+++ b/src/frontend/qt_sdl/PlatformConfig.h
@@ -73,6 +73,7 @@ extern int ShowOSD;
 
 extern int ConsoleType;
 extern int DirectBoot;
+extern int CheckUpdateOnStart;
 
 extern int SocketBindAnyAddr;
 extern char LANDevice[128];

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -1277,6 +1277,9 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
 
     actLimitFramerate->setChecked(Config::LimitFPS != 0);
     actAudioSync->setChecked(Config::AudioSync != 0);
+
+    if (Config::CheckUpdateOnStart)
+        onCheckForUpdates();
 }
 
 MainWindow::~MainWindow()

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -2033,8 +2033,7 @@ void MainWindow::onCheckForUpdates()
 
     QObject *signalSource = QObject::sender();
     connect(reply, &QNetworkReply::finished, [=]() {
-
-        if(reply->error() != QNetworkReply::NoError) {
+        if (reply->error() != QNetworkReply::NoError) {
             printf("Failed to check for updates: %s\n", reply->errorString().toStdString().c_str());
             QMessageBox::critical(this, "Error Fetching Updates", reply->errorString());
             return;
@@ -2050,13 +2049,13 @@ void MainWindow::onCheckForUpdates()
             msgBoxText += latestVersion + "\n";
             int ret = QMessageBox::information(this, "Update Available", msgBoxText + "Current Verion: " + MELONDS_VERSION
                                                , QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
-            if(ret == QMessageBox::Yes)
+            if (ret == QMessageBox::Yes)
                 QDesktopServices::openUrl(QUrl(MELONDS_URL "downloads.php"));
 
         }
         else
         {
-            if(signalSource != nullptr) // Show msgbox only when user explicitly checks for updates
+            if (signalSource != nullptr) // Show msgbox only when user explicitly checks for updates
                 QMessageBox::information(this, "No Update Found", "You are already running the latest version");
         }
 

--- a/src/frontend/qt_sdl/main.h
+++ b/src/frontend/qt_sdl/main.h
@@ -226,6 +226,8 @@ private slots:
     void onChangeLimitFramerate(bool checked);
     void onChangeAudioSync(bool checked);
 
+    void onCheckForUpdates();
+
     void onTitleUpdate(QString title);
 
     void onEmuStart();
@@ -277,6 +279,8 @@ public:
     QAction* actShowOSD;
     QAction* actLimitFramerate;
     QAction* actAudioSync;
+
+    QAction *actCheckForUpdates;
 };
 
 #endif // MAIN_H

--- a/src/version.h
+++ b/src/version.h
@@ -23,5 +23,7 @@
 
 #define MELONDS_URL        "http://melonds.kuribo64.net/"
 
+#define MELONDS_API_URL    "https://api.github.com/repos/Arisotura/melonDS/releases/latest"
+
 #endif // VERSION_H
 


### PR DESCRIPTION
Stuff in this PR - 

1. Check for updates manually under About > Check for Updates. 
![image](https://user-images.githubusercontent.com/4457834/96026665-73feb680-0e74-11eb-87da-d2d72fbbc82b.png)

2. Automatically check for updates on start under Config > Emu Settings > General
![image](https://user-images.githubusercontent.com/4457834/96026872-b88a5200-0e74-11eb-95a5-06cbbd39954f.png)
 
When an update is available, the new and current version numbers are displayed along with a Yes/No option to open the download page (http://melonds.kuribo64.net/downloads.php) in the browser.

![image](https://user-images.githubusercontent.com/4457834/96028026-69ddb780-0e76-11eb-87d4-ff843097c758.png)

When no update is available, there are 2 cases - if the user had manually checked for an update, then an info box is shown. If the update check was automatically triggered at boot, then no dialog box is shown and the user can peacefully continue working.

![image](https://user-images.githubusercontent.com/4457834/96028213-a4475480-0e76-11eb-9639-5faf194327a2.png)

Fixes #469 

