### PR TITLE
Add radio buttons to switch between Direct and Indirect Mode

### DIFF
--- a/src/frontend/qt_sdl/WifiSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/WifiSettingsDialog.cpp
@@ -54,7 +54,7 @@ WifiSettingsDialog::WifiSettingsDialog(QWidget* parent) : QDialog(parent), ui(ne
     LAN_Socket::Init();
     haspcap = LAN_PCap::Init(false);
 
-    ui->cbDirectMode->setText("Direct mode (requires " PCAP_NAME " and ethernet connection)");
+    ui->rbDirectMode->setText("Direct mode (requires " PCAP_NAME " and ethernet connection)");
 
     ui->cbBindAnyAddr->setChecked(Config::SocketBindAnyAddr != 0);
     ui->cbRandomizeMAC->setChecked(Config::RandomizeMAC != 0);
@@ -71,8 +71,9 @@ WifiSettingsDialog::WifiSettingsDialog(QWidget* parent) : QDialog(parent), ui(ne
     }
     ui->cbxDirectAdapter->setCurrentIndex(sel);
 
-    ui->cbDirectMode->setChecked(Config::DirectLAN != 0);
-    if (!haspcap) ui->cbDirectMode->setEnabled(false);
+    ui->rbDirectMode->setChecked(Config::DirectLAN != 0);
+    ui->rbIndirectMode->setChecked(Config::DirectLAN == 0);
+    if (!haspcap) ui->rbDirectMode->setEnabled(false);
 
     updateAdapterControls();
 }
@@ -101,7 +102,7 @@ void WifiSettingsDialog::done(int r)
 
         Config::SocketBindAnyAddr = ui->cbBindAnyAddr->isChecked() ? 1:0;
         Config::RandomizeMAC = randommac;
-        Config::DirectLAN = ui->cbDirectMode->isChecked() ? 1:0;
+        Config::DirectLAN = ui->rbDirectMode->isChecked() ? 1:0;
 
         int sel = ui->cbxDirectAdapter->currentIndex();
         if (sel < 0 || sel >= LAN_PCap::NumAdapters) sel = 0;
@@ -125,11 +126,14 @@ void WifiSettingsDialog::done(int r)
     closeDlg();
 }
 
-void WifiSettingsDialog::on_cbDirectMode_stateChanged(int state)
+void WifiSettingsDialog::on_rbDirectMode_clicked()
 {
     updateAdapterControls();
 }
-
+void WifiSettingsDialog::on_rbIndirectMode_clicked()
+{
+    updateAdapterControls();
+}
 void WifiSettingsDialog::on_cbxDirectAdapter_currentIndexChanged(int sel)
 {
     if (!haspcap) return;
@@ -153,7 +157,7 @@ void WifiSettingsDialog::on_cbxDirectAdapter_currentIndexChanged(int sel)
 
 void WifiSettingsDialog::updateAdapterControls()
 {
-    bool enable = haspcap && ui->cbDirectMode->isChecked();
+    bool enable = haspcap && ui->rbDirectMode->isChecked();
 
     ui->cbxDirectAdapter->setEnabled(enable);
     ui->lblAdapterMAC->setEnabled(enable);

--- a/src/frontend/qt_sdl/WifiSettingsDialog.h
+++ b/src/frontend/qt_sdl/WifiSettingsDialog.h
@@ -55,7 +55,8 @@ public:
 private slots:
     void done(int r);
 
-    void on_cbDirectMode_stateChanged(int state);
+    void on_rbDirectMode_clicked();
+    void on_rbIndirectMode_clicked();
     void on_cbxDirectAdapter_currentIndexChanged(int sel);
 
 private:

--- a/src/frontend/qt_sdl/WifiSettingsDialog.ui
+++ b/src/frontend/qt_sdl/WifiSettingsDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>479</width>
-    <height>240</height>
+    <width>572</width>
+    <height>296</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -58,67 +58,86 @@
       <string>Online</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_2">
+      <item row="3" column="0" rowspan="3" colspan="2">
+       <widget class="QGroupBox" name="groupBox_3">
+        <property name="title">
+         <string>Direct Mode Settings</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_3">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Network adapter:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="cbxDirectAdapter">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>300</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="whatsThis">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Selects the network adapter through which to route network traffic under direct mode.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>MAC address:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLabel" name="lblAdapterMAC">
+           <property name="text">
+            <string>[PLACEHOLDER]</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>IP address:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLabel" name="lblAdapterIP">
+           <property name="text">
+            <string>[PLACEHOLDER]</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QRadioButton" name="rbIndirectMode">
+        <property name="whatsThis">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Indirect mode uses libslirp. It requires no extra setup and is easy to use.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
         <property name="text">
-         <string>MAC address:</string>
+         <string>Indirect Mode (uses libslirp, recommended)</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="0" colspan="2">
-       <widget class="QCheckBox" name="cbDirectMode">
+      <item row="2" column="0">
+       <widget class="QRadioButton" name="rbDirectMode">
         <property name="whatsThis">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Direct mode directly routes network traffic to the host network. It is the most reliable, but requires an ethernet connection.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Non-direct mode uses a layer of emulation to get around this, but is more prone to problems.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
          <string>Direct mode [TEXT PLACEHOLDER]</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="cbxDirectAdapter">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>350</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Selects the network adapter through which to route network traffic under direct mode.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Network adapter:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>IP address:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QLabel" name="lblAdapterMAC">
-        <property name="text">
-         <string>[PLACEHOLDER]</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QLabel" name="lblAdapterIP">
-        <property name="text">
-         <string>[PLACEHOLDER]</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Quite a few questions come up about on how to use Direct Mode, because they don't know that Indirect Mode exists, such as [this](https://melonds.kuribo64.net/board/thread.php?id=566) and [this](https://melonds.kuribo64.net/board/thread.php?id=541).

This PR changes the "Direct Mode" checkbox to a radio button, adds an "Indirect Mode" radio button, and creates a group called "Direct Mode Settings" that is only enabled when "Direct Mode" is selected.

How it looks:
![image](https://user-images.githubusercontent.com/68647953/99905716-8ae1c580-2cca-11eb-85ae-344b66c54e85.png)
![image](https://user-images.githubusercontent.com/68647953/99905742-b4025600-2cca-11eb-9cf1-d313d41314ad.png)
