### PR TITLE
CMake build fixups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 project(melonDS CXX)
 
 set(CMAKE_C_STANDARD 11)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 check_library_exists(m pow "" LIBM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,28 @@
 cmake_minimum_required(VERSION 3.13)
 
+include(CheckSymbolExists)
+include(CheckLibraryExists)
+
 cmake_policy(VERSION 3.13)
 if (POLICY CMP0076)
     cmake_policy(SET CMP0076 NEW)
 endif()
 
-set(CMAKE_CXX_STANDARD 11)
+project(melonDS CXX)
+
+set(C_STANDARD 11)
+set(CXX_STANDARD 14)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
-project(melonDS)
-
-if (NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
+check_library_exists(m pow "" LIBM)
+if(LIBM)
+    link_libraries(m)
 endif()
 
-include(CheckSymbolExists)
+if (NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
 function(detect_architecture symbol arch)
     if (NOT DEFINED ARCHITECTURE)
         set(CMAKE_REQUIRED_QUIET 1)
@@ -66,18 +74,8 @@ if (CMAKE_BUILD_TYPE STREQUAL Release)
 endif()
 
 if (ENABLE_LTO)
-	add_compile_options(-flto)
-	add_link_options(-flto)
-
-	if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
-		set(CMAKE_AR "gcc-ar")
-		set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> qcs <TARGET> <LINK_FLAGS> <OBJECTS>")
-		set(CMAKE_C_ARCHIVE_FINISH   true)
-		set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> qcs <TARGET> <LINK_FLAGS> <OBJECTS>")
-		set(CMAKE_CXX_ARCHIVE_FINISH   true)
-	elseif (CMAKE_C_COMPILER_ID STREQUAL "Clang")
-		set(CMAKE_AR "llvm-ar")
-	endif()
+    add_compile_options(-flto)
+	add_link_options(-flto -fuse-linker-plugin)
 endif()
 
 option(BUILD_QT_SDL "Build Qt/SDL frontend" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,8 @@ endif()
 
 project(melonDS CXX)
 
-set(C_STANDARD 11)
-set(CXX_STANDARD 14)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 check_library_exists(m pow "" LIBM)


### PR DESCRIPTION
* Correctly set C/C++ standard
* Specify CXX in project() to get things set up right, also causes it to
link using the C++ compiler which is necessary for LTO builds with Clang
to work right
* Remove Fedora/flatpak build workaround, no longer needed with C++ standard set
* Link libm explicitly if we need to
* Specify -fuse-linker-plugin when building with LTO just in case