### PR TITLE
Ignore all .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ cmake-build-debug
 .idea
 
 *.exe
+
+.DS_Store


### PR DESCRIPTION
The .DS_Store file is created by macOS.
From Wikipedia:
>  .DS_Store is a file that stores custom attributes of its containing folder, such as the position of icons or the choice of a background image.

This is unneeded and can be deleted.

Dolphin does this - https://github.com/dolphin-emu/dolphin/blob/2952f99f691e69e450c5ac52dca9516483ade2ee/.gitignore#L4
