### PR TITLE
Fix JIT linkage on ARM64 Macs

### DIFF
--- a/src/ARMJIT_A64/ARMJIT_Linkage.S
+++ b/src/ARMJIT_A64/ARMJIT_Linkage.S
@@ -8,8 +8,13 @@
 
 .p2align 4,,15
 
+#ifdef __APPLE__
+.global _ARM_Dispatch
+_ARM_Dispatch:
+#else
 .global ARM_Dispatch
 ARM_Dispatch:
+#endif
     stp x19, x20, [sp, #-96]!
     stp x21, x22, [sp, #16]
     stp x23, x24, [sp, #32]
@@ -25,8 +30,13 @@ ARM_Dispatch:
 
 .p2align 4,,15
 
+#ifdef __APPLE__
+.global _ARM_Ret
+_ARM_Ret:
+#else
 .global ARM_Ret
 ARM_Ret:
+#endif
     str RCycles, [RCPU, ARM_Cycles_offset]
     str RCPSR, [RCPU, ARM_CPSR_offset]
 


### PR DESCRIPTION
This fix has been done for x86-64 Macs, but not the new ARM64 Macs.
In the Mach-O format (used in macOS) global function names in assembly must be prepended with an underscore.