### PR TITLE
Fix the ARM64 Code Emitter on macOS

### DIFF
--- a/src/dolphin/Arm64Emitter.cpp
+++ b/src/dolphin/Arm64Emitter.cpp
@@ -15,6 +15,10 @@
 #include "../types.h"
 #include "MathUtil.h"
 
+#ifdef __APPLE__
+    #include <libkern/OSCacheControl.h>
+#endif
+
 namespace Arm64Gen
 {
 namespace
@@ -384,7 +388,7 @@ void ARM64XEmitter::FlushIcacheSection(u8* start, u8* end)
   if (start == end)
     return;
 
-#if defined(IOS)
+#if defined(__APPLE__)
   // Header file says this is equivalent to: sys_icache_invalidate(start, end - start);
   sys_cache_control(kCacheFunctionPrepareForExecution, start, end - start);
 #else


### PR DESCRIPTION
The JIT Recompiler's Code Emitter tries to clear the CPU's instruction cache in assembly which fails on ARM64 Macs. However, macOS does have a kernel specific function (also in iOS). The iOS icache clearing code was changed to run on all Apple systems.