### PR TITLE
Set menubar height to 0 in fullscreen

### DIFF
--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -1991,12 +1991,12 @@ void MainWindow::onFullscreenToggled()
     if (!mainWindow->isFullScreen())
     {
         mainWindow->showFullScreen();
-        mainWindow->menuBar()->hide();
+        mainWindow->menuBar()->setFixedHeight(0); // Don't use hide() as menubar actions stop working
     }
     else
     {
         mainWindow->showNormal();
-        mainWindow->menuBar()->show();
+        mainWindow->menuBar()->setFixedSize(mainWindow->menuBar()->sizeHint());
     }
 }
 

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -1996,7 +1996,8 @@ void MainWindow::onFullscreenToggled()
     else
     {
         mainWindow->showNormal();
-        mainWindow->menuBar()->setFixedSize(mainWindow->menuBar()->sizeHint());
+        int menuBarHeight = mainWindow->menuBar()->sizeHint().height();
+        mainWindow->menuBar()->setFixedHeight(menuBarHeight);
     }
 }
 


### PR DESCRIPTION
* Avoid using hide() on the mainwindow's menubar as it breaks menubar
actions.

* Fixes save/load state shortcuts not working in fullscreen (#922)

Signed-off-by: Madhav Kanbur <abcdjdj@gmail.com>