### PR TITLE
Fix FreeBSD undefined identifier issues in Lan_PCap.cpp

### DIFF
--- a/src/frontend/qt_sdl/LAN_PCap.cpp
+++ b/src/frontend/qt_sdl/LAN_PCap.cpp
@@ -36,7 +36,8 @@
         #ifdef __linux__
             #include <linux/if_packet.h>
         #else
-	    #include <net/if_dl.h>
+            #include <net/if.h>
+            #include <net/if_dl.h>
         #endif
 #endif
 


### PR DESCRIPTION
FreeBSD requires net/if.h to be included as well.