### PR TITLE
Polish up archive support

### DIFF
--- a/src/GBACart.cpp
+++ b/src/GBACart.cpp
@@ -620,7 +620,7 @@ void DoSavestate(Savestate* file)
     if (HasSolarSensor) GBACart_SolarSensor::DoSavestate(file);
 }
 
-static void LoadROMCommon(const char *sram)
+void LoadROMCommon(const char *sram)
 {
     char gamecode[5] = { '\0' };
     memcpy(&gamecode, CartROM + 0xAC, 4);

--- a/src/GBACart.cpp
+++ b/src/GBACart.cpp
@@ -677,6 +677,20 @@ bool LoadROM(const char* path, const char* sram)
     return true;
 }
 
+bool LoadROM(const u8* romdata, u32 filelength, const char *sram)
+{
+    CartROMSize = 0x200;
+    while (CartROMSize < filelength)
+        CartROMSize <<= 1;
+
+    CartROM = new u8[CartROMSize];
+    memcpy(CartROM, romdata, filelength);
+
+    LoadROMCommon(sram);
+
+    return true;
+}
+
 void RelocateSave(const char* path, bool write)
 {
     // derp herp

--- a/src/GBACart.h
+++ b/src/GBACart.h
@@ -66,6 +66,7 @@ void Eject();
 
 void DoSavestate(Savestate* file);
 bool LoadROM(const char* path, const char* sram);
+bool LoadROM(const u8* romdata, u32 filelength, const char *sram);
 void RelocateSave(const char* path, bool write);
 
 void WriteGPIO(u32 addr, u16 val);

--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -864,6 +864,19 @@ bool LoadGBAROM(const char* path, const char* sram)
     }
 }
 
+bool LoadGBAROM(const u8* romdata, u32 filelength, const char *filename, const char *sram)
+{
+    if (GBACart::LoadROM(romdata, filelength, sram))
+    {
+        return true;
+    }
+    else
+    {
+        printf("Failed to load ROM %s from archive\n", filename);
+        return false;
+    }
+}
+
 void LoadBIOS()
 {
     Reset();

--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -823,6 +823,20 @@ void SetConsoleType(int type)
     ConsoleType = type;
 }
 
+bool LoadROM(const u8* romdata, u32 filelength, const char *sram, bool direct)
+{
+    if (NDSCart::LoadROM(romdata, filelength, sram, direct))
+    {
+        Running = true;
+        return true;
+    }
+    else
+    {
+        printf("Failed to load ROM from archive\n");
+        return false;
+    }
+}
+
 bool LoadROM(const char* path, const char* sram, bool direct)
 {
     if (NDSCart::LoadROM(path, sram, direct))

--- a/src/NDS.h
+++ b/src/NDS.h
@@ -193,6 +193,7 @@ void SetARM7RegionTimings(u32 addrstart, u32 addrend, int buswidth, int nonseq, 
 void SetConsoleType(int type);
 
 bool LoadROM(const char* path, const char* sram, bool direct);
+bool LoadROM(const u8* romdata, u32 filelength, const char *sram, bool direct);
 bool LoadGBAROM(const char* path, const char* sram);
 void LoadBIOS();
 void SetupDirectBoot();

--- a/src/NDS.h
+++ b/src/NDS.h
@@ -195,6 +195,7 @@ void SetConsoleType(int type);
 bool LoadROM(const char* path, const char* sram, bool direct);
 bool LoadROM(const u8* romdata, u32 filelength, const char *sram, bool direct);
 bool LoadGBAROM(const char* path, const char* sram);
+bool LoadGBAROM(const u8* romdata, u32 filelength, const char *filename, const char *sram);
 void LoadBIOS();
 void SetupDirectBoot();
 void RelocateSave(const char* path, bool write);

--- a/src/NDSCart.cpp
+++ b/src/NDSCart.cpp
@@ -1026,6 +1026,22 @@ bool LoadROM(const char* path, const char* sram, bool direct)
     return LoadROMCommon(len, sram, direct);
 }
 
+bool LoadROM(const u8* romdata, u32 filelength, const char *sram, bool direct)
+{
+    NDS::Reset();
+
+    u32 len = filelength;
+    CartROMSize = 0x200;
+    while (CartROMSize < len)
+        CartROMSize <<= 1;
+
+    CartROM = new u8[CartROMSize];
+    memset(CartROM, 0, CartROMSize);
+    memcpy(CartROM, romdata, filelength);
+
+    return LoadROMCommon(filelength, sram, direct);
+}
+
 void RelocateSave(const char* path, bool write)
 {
     // herp derp

--- a/src/NDSCart.cpp
+++ b/src/NDSCart.cpp
@@ -885,7 +885,7 @@ void DecryptSecureArea(u8* out)
     }
 }
 
-static bool LoadROMCommon(u32 filelength, const char *sram, bool direct)
+bool LoadROMCommon(u32 filelength, const char *sram, bool direct)
 {
     u32 gamecode;
     memcpy(&gamecode, CartROM + 0x0C, 4);

--- a/src/NDSCart.h
+++ b/src/NDSCart.h
@@ -46,6 +46,7 @@ void DoSavestate(Savestate* file);
 
 void DecryptSecureArea(u8* out);
 bool LoadROM(const char* path, const char* sram, bool direct);
+bool LoadROM(const u8* romdata, u32 filelength, const char *sram, bool direct);
 
 void FlushSRAMFile();
 

--- a/src/frontend/FrontendUtil.h
+++ b/src/frontend/FrontendUtil.h
@@ -19,9 +19,6 @@
 #ifndef FRONTENDUTIL_H
 #define FRONTENDUTIL_H
 
-#include <QByteArray>
-#include <QString>
-
 #include "types.h"
 
 namespace Frontend

--- a/src/frontend/FrontendUtil.h
+++ b/src/frontend/FrontendUtil.h
@@ -19,6 +19,9 @@
 #ifndef FRONTENDUTIL_H
 #define FRONTENDUTIL_H
 
+#include <QByteArray>
+#include <QString>
+
 #include "types.h"
 
 namespace Frontend
@@ -76,6 +79,7 @@ int LoadBIOS();
 // load a ROM file to the specified cart slot
 // note: loading a ROM to the NDS slot resets emulation
 int LoadROM(const char* file, int slot);
+int LoadROM(const QByteArray *romdata, QString archivefilename, QString romfilename, int slot);
 
 // unload the ROM loaded in the specified cart slot
 // simulating ejection of the cartridge

--- a/src/frontend/FrontendUtil.h
+++ b/src/frontend/FrontendUtil.h
@@ -66,6 +66,8 @@ extern char ROMPath [ROMSlot_MAX][1024];
 extern char SRAMPath[ROMSlot_MAX][1024];
 extern bool SavestateLoaded;
 
+// Stores type of nds rom i.e. nds/srl/dsi. Should be updated everytime an NDS rom is loaded from an archive
+extern char NDSROMExtension[4];
 
 // initialize the ROM handling utility
 void Init_ROM();
@@ -79,7 +81,7 @@ int LoadBIOS();
 // load a ROM file to the specified cart slot
 // note: loading a ROM to the NDS slot resets emulation
 int LoadROM(const char* file, int slot);
-int LoadROM(const QByteArray *romdata, QString archivefilename, QString romfilename, int slot);
+int LoadROM(const u8 *romdata, u32 romlength, const char *archivefilename, const char *romfilename, const char *sramfilename, int slot);
 
 // unload the ROM loaded in the specified cart slot
 // simulating ejection of the cartridge

--- a/src/frontend/Util_ROM.cpp
+++ b/src/frontend/Util_ROM.cpp
@@ -570,15 +570,22 @@ void GetSavestateName(int slot, char* filename, int len)
     }
     else
     {
-        int l = strlen(ROMPath[ROMSlot_NDS]);
+        char *rompath;
+        QString _filename(ROMPath[ROMSlot_NDS]);
+        if(_filename.endsWith(".nds") || _filename.endsWith(".srl") || _filename.endsWith(".dsi"))
+            rompath = ROMPath[ROMSlot_NDS];
+        else
+            rompath = SRAMPath[ROMSlot_NDS]; // If archive, construct ssname from sram file
+
+        int l = strlen(rompath);
         pos = l;
-        while (ROMPath[ROMSlot_NDS][pos] != '.' && pos > 0) pos--;
+        while (rompath[pos] != '.' && pos > 0) pos--;
         if (pos == 0) pos = l;
 
         // avoid buffer overflow. shoddy
         if (pos > len-5) pos = len-5;
 
-        strncpy(&filename[0], ROMPath[ROMSlot_NDS], pos);
+        strncpy(&filename[0], rompath, pos);
     }
     strcpy(&filename[pos], ".ml");
     filename[pos+3] = '0'+slot;

--- a/src/frontend/Util_ROM.cpp
+++ b/src/frontend/Util_ROM.cpp
@@ -506,7 +506,7 @@ int Reset()
     else
     {
         QString fileName(ROMPath[ROMSlot_NDS]);
-        if(fileName.endsWith(".nds"))
+        if(fileName.endsWith(".nds") || fileName.endsWith(".srl") || fileName.endsWith(".dsi"))
         {
             SetupSRAMPath(0);
             if (!NDS::LoadROM(ROMPath[ROMSlot_NDS], SRAMPath[ROMSlot_NDS], directboot))

--- a/src/frontend/Util_ROM.cpp
+++ b/src/frontend/Util_ROM.cpp
@@ -19,7 +19,9 @@
 #include <stdio.h>
 #include <string.h>
 
+#ifdef ARCHIVE_SUPPORT_ENABLED
 #include "ArchiveUtil.h"
+#endif
 #include "FrontendUtil.h"
 #include "Config.h"
 #include "SharedConfig.h"
@@ -530,6 +532,7 @@ int Reset()
             if (!NDS::LoadROM(ROMPath[ROMSlot_NDS], SRAMPath[ROMSlot_NDS], directboot))
                 return Load_ROMLoadError;
         }
+#ifdef ARCHIVE_SUPPORT_ENABLED
         else
         {
             u8 *romdata = nullptr; u32 romlen;
@@ -552,7 +555,7 @@ int Reset()
             if(!ok)
                 return Load_ROMLoadError;
         }
-
+#endif
     }
 
     if (ROMPath[ROMSlot_GBA][0] != '\0')
@@ -566,6 +569,7 @@ int Reset()
             if (!NDS::LoadGBAROM(ROMPath[ROMSlot_GBA], SRAMPath[ROMSlot_GBA]))
                 return Load_ROMLoadError;
         }
+#ifdef ARCHIVE_SUPPORT_ENABLED
         else
         {
             u8 *romdata = nullptr; u32 romlen;
@@ -588,7 +592,7 @@ int Reset()
             if(!ok)
                 return Load_ROMLoadError;
         }
-
+#endif
     }
 
     LoadCheats();

--- a/src/frontend/Util_ROM.cpp
+++ b/src/frontend/Util_ROM.cpp
@@ -536,11 +536,11 @@ int Reset()
             char romfilename[1024] = {0}, sramfilename[1024];
             strncpy(sramfilename, SRAMPath[ROMSlot_NDS], 1024); // Use existing SRAMPath
 
-            int pos = strlen(sramfilename) - 1;
-            while(pos > 0 && sramfilename[pos] != '/' && sramfilename[pos] != '\\')
-                --pos;
+            char *pos = strrchr(sramfilename, '/');
+            if(!pos)
+                pos = strrchr(sramfilename, '\\');
 
-            strncpy(romfilename, &sramfilename[pos + 1], 1024);
+            strncpy(romfilename, pos + 1, 1024);
             strncpy(&romfilename[strlen(romfilename) - 3], NDSROMExtension, 3); // extension could be nds, srl or dsi
             printf("RESET loading from archive : %s\n", romfilename);
             romlen = Archive::ExtractFileFromArchive(ROMPath[ROMSlot_NDS], romfilename, &romdata);
@@ -572,11 +572,11 @@ int Reset()
             char romfilename[1024] = {0}, sramfilename[1024];
             strncpy(sramfilename, SRAMPath[ROMSlot_GBA], 1024); // Use existing SRAMPath
 
-            int pos = strlen(sramfilename) - 1;
-            while(pos > 0 && sramfilename[pos] != '/' && sramfilename[pos] != '\\')
-                --pos;
+            char *pos = strrchr(sramfilename, '/');
+            if(!pos)
+                pos = strrchr(sramfilename, '\\');
 
-            strncpy(romfilename, &sramfilename[pos + 1], 1024);
+            strncpy(romfilename, pos + 1, 1024);
             strncpy(&romfilename[strlen(romfilename) - 3], "gba", 3);
             printf("RESET loading from archive : %s\n", romfilename);
             romlen = Archive::ExtractFileFromArchive(ROMPath[ROMSlot_GBA], romfilename, &romdata);

--- a/src/frontend/Util_ROM.cpp
+++ b/src/frontend/Util_ROM.cpp
@@ -539,11 +539,11 @@ int Reset()
             char romfilename[1024] = {0}, sramfilename[1024];
             strncpy(sramfilename, SRAMPath[ROMSlot_NDS], 1024); // Use existing SRAMPath
 
-            char *pos = strrchr(sramfilename, '/');
-            if(!pos)
-                pos = strrchr(sramfilename, '\\');
+            int pos = strlen(sramfilename) - 1;
+            while(pos > 0 && sramfilename[pos] != '/' && sramfilename[pos] != '\\')
+                --pos;
 
-            strncpy(romfilename, pos + 1, 1024);
+            strncpy(romfilename, &sramfilename[pos + 1], 1024);
             strncpy(&romfilename[strlen(romfilename) - 3], NDSROMExtension, 3); // extension could be nds, srl or dsi
             printf("RESET loading from archive : %s\n", romfilename);
             romlen = Archive::ExtractFileFromArchive(ROMPath[ROMSlot_NDS], romfilename, &romdata);
@@ -576,11 +576,11 @@ int Reset()
             char romfilename[1024] = {0}, sramfilename[1024];
             strncpy(sramfilename, SRAMPath[ROMSlot_GBA], 1024); // Use existing SRAMPath
 
-            char *pos = strrchr(sramfilename, '/');
-            if(!pos)
-                pos = strrchr(sramfilename, '\\');
+            int pos = strlen(sramfilename) - 1;
+            while(pos > 0 && sramfilename[pos] != '/' && sramfilename[pos] != '\\')
+                --pos;
 
-            strncpy(romfilename, pos + 1, 1024);
+            strncpy(romfilename, &sramfilename[pos + 1], 1024);
             strncpy(&romfilename[strlen(romfilename) - 3], "gba", 3);
             printf("RESET loading from archive : %s\n", romfilename);
             romlen = Archive::ExtractFileFromArchive(ROMPath[ROMSlot_GBA], romfilename, &romdata);

--- a/src/frontend/Util_ROM.cpp
+++ b/src/frontend/Util_ROM.cpp
@@ -320,7 +320,7 @@ int LoadROM(const u8 *romdata, u32 romlength, const char *archivefilename, const
         res = VerifyDSiFirmware();
         if (res != Load_OK) return res;
 
-        res = VerifyDSiNAND();
+        res = SetupDSiNAND();
         if (res != Load_OK) return res;
 
         GBACart::Eject();

--- a/src/frontend/Util_ROM.cpp
+++ b/src/frontend/Util_ROM.cpp
@@ -350,13 +350,13 @@ int LoadROM(const QByteArray *romdata, QString archivefilename, QString romfilen
         strncpy(PrevSRAMPath[slot], SRAMPath[slot], 1024); // safety
         return Load_OK;
     }
-    /*else if (slot == ROMSlot_GBA && NDS::LoadGBAROM(ROMPath[slot], SRAMPath[slot]))
+    else if (slot == ROMSlot_GBA && NDS::LoadGBAROM((const u8*)romdata->constData(), romdata->size(), romfilename.toStdString().c_str(), SRAMPath[slot]))
     {
         SavestateLoaded = false; // checkme??
 
         strncpy(PrevSRAMPath[slot], SRAMPath[slot], 1024); // safety
         return Load_OK;
-    }*/
+    }
     else
     {
         strncpy(ROMPath[slot], oldpath, 1024);

--- a/src/frontend/qt_sdl/ArchiveUtil.cpp
+++ b/src/frontend/qt_sdl/ArchiveUtil.cpp
@@ -92,5 +92,21 @@ QVector<QString> ExtractFileFromArchive(const char* path, const char* wantedFile
 
 }
 
+u32 ExtractFileFromArchive(const char* path, const char* wantedFile, u8 **romdata)
+{
+    QByteArray romBuffer;
+    QVector<QString> extractResult = ExtractFileFromArchive(path, wantedFile, &romBuffer);
+
+    if(extractResult[0] == "Err")
+    {
+        return 0;
+    }
+
+    u32 len = romBuffer.size();
+    *romdata = new u8[romBuffer.size()];
+    memcpy(*romdata, romBuffer.data(), len);
+
+    return len;
+}
 
 }

--- a/src/frontend/qt_sdl/ArchiveUtil.cpp
+++ b/src/frontend/qt_sdl/ArchiveUtil.cpp
@@ -91,9 +91,10 @@ QVector<QString> ExtractFileFromArchive(const char* path, const char* wantedFile
         archiveBuffer.reset(nullptr);
         return QVector<QString> {"Err", archive_error_string(a)};
     }
-    QString nameToWrite = QFileInfo(path).absolutePath() + "/" + QFileInfo(path).baseName() + "/" + archive_entry_pathname(entry);
+    QString extractToFolder = QFileInfo(path).absolutePath() + "/" + QFileInfo(path).baseName();
+    mkdir(extractToFolder.toUtf8().constData(), 600); // Create directory otherwise fopen will not open the file
 
-    mkdir(QFileInfo(path).baseName().toUtf8().constData(), 600); // Create directory otherwise fopen will not open the file
+    QString nameToWrite = extractToFolder + "/" + archive_entry_pathname(entry);
     FILE* fileToWrite = fopen(nameToWrite.toUtf8().constData(), "wb");
     fwrite((char*)archiveBuffer.get(), bytesToWrite, 1, fileToWrite);
     fclose(fileToWrite);

--- a/src/frontend/qt_sdl/ArchiveUtil.h
+++ b/src/frontend/qt_sdl/ArchiveUtil.h
@@ -19,6 +19,7 @@ namespace Archive
     
 QVector<QString> ListArchive(const char* path);
 QVector<QString> ExtractFileFromArchive(const char* path, const char* wantedFile, QByteArray *romBuffer);
+u32 ExtractFileFromArchive(const char* path, const char* wantedFile, u8 **romdata);
 
 }
 

--- a/src/frontend/qt_sdl/ArchiveUtil.h
+++ b/src/frontend/qt_sdl/ArchiveUtil.h
@@ -18,7 +18,7 @@ namespace Archive
 {
     
 QVector<QString> ListArchive(const char* path);
-QVector<QString> ExtractFileFromArchive(const char* path, const char* wantedFile);
+QVector<QString> ExtractFileFromArchive(const char* path, const char* wantedFile, QByteArray *romBuffer);
 
 }
 

--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -62,6 +62,7 @@ if (APPLE)
     list(APPEND CMAKE_PREFIX_PATH "${LIBARCHIVE_DIR}")
 endif()
 pkg_check_modules(LIBARCHIVE REQUIRED libarchive)
+add_compile_definitions(ARCHIVE_SUPPORT_ENABLED)
 
 if (WIN32 AND (CMAKE_BUILD_TYPE STREQUAL Release))
     add_executable(melonDS WIN32 ${SOURCES_QT_SDL})

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -1458,7 +1458,14 @@ void MainWindow::dropEvent(QDropEvent* event)
         else
         {
             slot = (romFileName.endsWith(".gba") ? 1 : 0);
-            res = Frontend::LoadROM(&romBuffer, _filename, romFileName, slot);
+            QString sramFileName = QFileInfo(_filename).absolutePath() + QDir::separator() + QFileInfo(romFileName).completeBaseName() + ".sav";
+
+            if(slot == 0)
+                strncpy(Frontend::NDSROMExtension, QFileInfo(romFileName).suffix().toStdString().c_str(), 4);
+
+            res = Frontend::LoadROM((const u8*)romBuffer.constData(), romBuffer.size(),
+                                    _filename, romFileName.toStdString().c_str(), sramFileName.toStdString().c_str(),
+                                    slot);
         }
     }
 
@@ -1533,16 +1540,25 @@ void MainWindow::loadROM(QByteArray *romData, QString archiveFileName, QString r
     // Strip entire archive name and get folder path
     strncpy(Config::LastROMFolder, QFileInfo(archiveFileName).absolutePath().toStdString().c_str(), 1024);
 
+    QString sramFileName = QFileInfo(archiveFileName).absolutePath() + QDir::separator() + QFileInfo(romFileName).completeBaseName() + ".sav";
+
     int slot; int res;
     if (romFileName.endsWith("gba"))
     {
         slot = 1;
-        res = Frontend::LoadROM(romData, archiveFileName, romFileName, Frontend::ROMSlot_GBA);
+        res = Frontend::LoadROM((const u8*)romData->constData(), romData->size(),
+                                archiveFileName.toStdString().c_str(),
+                                romFileName.toStdString().c_str(), sramFileName.toStdString().c_str(),
+                                Frontend::ROMSlot_GBA);
     }
     else
     {
+        strncpy(Frontend::NDSROMExtension, QFileInfo(romFileName).suffix().toStdString().c_str(), 4);
         slot = 0;
-        res = Frontend::LoadROM(romData, archiveFileName, romFileName, Frontend::ROMSlot_NDS);
+        res = Frontend::LoadROM((const u8*)romData->constData(), romData->size(),
+                                archiveFileName.toStdString().c_str(),
+                                romFileName.toStdString().c_str(), sramFileName.toStdString().c_str(),
+                                Frontend::ROMSlot_NDS);
     }
 
     if (res != Frontend::Load_OK)

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -1691,7 +1691,7 @@ QString MainWindow::pickAndExtractFileFromArchive(QString archiveFileName, QByte
         archiveROMList.removeFirst();
 
         bool ok;
-        QString toLoad = QInputDialog::getItem(nullptr, "melonDS",
+        QString toLoad = QInputDialog::getItem(this, "melonDS",
                                   "The archive was found to have multiple files. Select which ROM you want to load.", archiveROMList.toList(), 0, false, &ok);
         if(!ok) // User clicked on cancel
             return QString();
@@ -1704,7 +1704,7 @@ QString MainWindow::pickAndExtractFileFromArchive(QString archiveFileName, QByte
         }
         else
         {
-            QMessageBox::critical(nullptr, "melonDS", QString("There was an error while trying to extract the ROM from the archive: ") + extractResult[1]);
+            QMessageBox::critical(this, "melonDS", QString("There was an error while trying to extract the ROM from the archive: ") + extractResult[1]);
         }
     }
     else if (archiveROMList.size() == 2)
@@ -1717,16 +1717,16 @@ QString MainWindow::pickAndExtractFileFromArchive(QString archiveFileName, QByte
         }
         else
         {
-            QMessageBox::critical(nullptr, "melonDS", QString("There was an error while trying to extract the ROM from the archive: ") + extractResult[1]);
+            QMessageBox::critical(this, "melonDS", QString("There was an error while trying to extract the ROM from the archive: ") + extractResult[1]);
         }
     }
     else if ((archiveROMList.size() == 1) && (archiveROMList[0] == QString("OK")))
     {
-        QMessageBox::warning(nullptr, "melonDS", "The archive is intact, but there are no files inside.");
+        QMessageBox::warning(this, "melonDS", "The archive is intact, but there are no files inside.");
     }
     else
     {
-        QMessageBox::critical(nullptr, "melonDS", "The archive could not be read. It may be corrupt or you don't have the permissions.");
+        QMessageBox::critical(this, "melonDS", "The archive could not be read. It may be corrupt or you don't have the permissions.");
     }
 
     return romFileName;

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -1645,14 +1645,12 @@ void MainWindow::onOpenFileArchive()
         return;
     }
 
-    QByteArray *romBuffer = new QByteArray();
-    QString romFileName = pickAndExtractFileFromArchive(archiveFileName, romBuffer);
+    QByteArray romBuffer;
+    QString romFileName = pickAndExtractFileFromArchive(archiveFileName, &romBuffer);
     if(!romFileName.isEmpty())
     {
-        loadROM(romBuffer, archiveFileName, romFileName);
+        loadROM(&romBuffer, archiveFileName, romFileName);
     }
-
-    delete romBuffer;
 }
 
 QString MainWindow::pickAndExtractFileFromArchive(QString archiveFileName, QByteArray *romBuffer)
@@ -1753,14 +1751,13 @@ void MainWindow::onClickRecentFile()
     {
         // Archives
         QString archiveFileName = fileName;
-        QByteArray *romBuffer = new QByteArray;
-        QString romFileName = MainWindow::pickAndExtractFileFromArchive(archiveFileName, romBuffer);
+        QByteArray romBuffer;
+        QString romFileName = MainWindow::pickAndExtractFileFromArchive(archiveFileName, &romBuffer);
         if(!romFileName.isEmpty())
         {
             emuThread->emuPause();
-            loadROM(romBuffer, archiveFileName, romFileName);
+            loadROM(&romBuffer, archiveFileName, romFileName);
         }
-        delete romBuffer;
     }
 }
 

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -1507,20 +1507,17 @@ void MainWindow::loadROM(QByteArray *romData, QString archiveFileName, QString r
     strncpy(Config::LastROMFolder, QFileInfo(archiveFileName).absolutePath().toStdString().c_str(), 1024);
 
     int slot; int res;
-    /*if (!strcasecmp(ext, "gba"))
+    if (romFileName.endsWith("gba"))
     {
         slot = 1;
-        res = Frontend::LoadROM(file, Frontend::ROMSlot_GBA);
+        res = Frontend::LoadROM(romData, archiveFileName, romFileName, Frontend::ROMSlot_GBA);
     }
     else
     {
         slot = 0;
-        res = Frontend::LoadROM(file, Frontend::ROMSlot_NDS);
-    }*/
+        res = Frontend::LoadROM(romData, archiveFileName, romFileName, Frontend::ROMSlot_NDS);
+    }
 
-    // TODO: GBA support here!
-    slot = 0;
-    res = Frontend::LoadROM(romData, archiveFileName, romFileName, Frontend::ROMSlot_NDS);
     if (res != Frontend::Load_OK)
     {
         QMessageBox::critical(this,

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -1742,7 +1742,7 @@ void MainWindow::onClickRecentFile()
     QAction *act = (QAction *)sender();
     QString fileName = act->data().toString();
 
-    if(fileName.endsWith(".gba") || fileName.endsWith(".nds"))
+    if(fileName.endsWith(".gba") || fileName.endsWith(".nds") || fileName.endsWith(".srl") || fileName.endsWith(".dsi"))
     {
         emuThread->emuPause();
         loadROM(fileName);

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -1718,12 +1718,12 @@ void MainWindow::updateRecentFilesMenu()
 
 void MainWindow::onClickRecentFile()
 {
-    emuThread->emuPause();
     QAction *act = (QAction *)sender();
     QString fileName = act->data().toString();
 
     if(fileName.endsWith(".gba") || fileName.endsWith(".nds"))
     {
+        emuThread->emuPause();
         loadROM(fileName);
     }
     else
@@ -1734,6 +1734,7 @@ void MainWindow::onClickRecentFile()
         QString romFileName = MainWindow::pickAndExtractFileFromArchive(archiveFileName, romBuffer);
         if(!romFileName.isEmpty())
         {
+            emuThread->emuPause();
             loadROM(romBuffer, archiveFileName, romFileName);
         }
         delete romBuffer;

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -1645,7 +1645,7 @@ QString MainWindow::pickAndExtractFileFromArchive(QString archiveFileName, QByte
         archiveROMList.removeFirst();
 
         bool ok;
-        QString toLoad = QInputDialog::getItem(this, "melonDS",
+        QString toLoad = QInputDialog::getItem(nullptr, "melonDS",
                                   "The archive was found to have multiple files. Select which ROM you want to load.", archiveROMList.toList(), 0, false, &ok);
         if(!ok) // User clicked on cancel
             return QString();
@@ -1658,7 +1658,7 @@ QString MainWindow::pickAndExtractFileFromArchive(QString archiveFileName, QByte
         }
         else
         {
-            QMessageBox::critical(this, "melonDS", QString("There was an error while trying to extract the ROM from the archive: ") + extractResult[1]);
+            QMessageBox::critical(nullptr, "melonDS", QString("There was an error while trying to extract the ROM from the archive: ") + extractResult[1]);
         }
     }
     else if (archiveROMList.size() == 2)
@@ -1671,16 +1671,16 @@ QString MainWindow::pickAndExtractFileFromArchive(QString archiveFileName, QByte
         }
         else
         {
-            QMessageBox::critical(this, "melonDS", QString("There was an error while trying to extract the ROM from the archive: ") + extractResult[1]);
+            QMessageBox::critical(nullptr, "melonDS", QString("There was an error while trying to extract the ROM from the archive: ") + extractResult[1]);
         }
     }
     else if ((archiveROMList.size() == 1) && (archiveROMList[0] == QString("OK")))
     {
-        QMessageBox::warning(this, "melonDS", "The archive is intact, but there are no files inside.");
+        QMessageBox::warning(nullptr, "melonDS", "The archive is intact, but there are no files inside.");
     }
     else
     {
-        QMessageBox::critical(this, "melonDS", "The archive could not be read. It may be corrupt or you don't have the permissions.");
+        QMessageBox::critical(nullptr, "melonDS", "The archive could not be read. It may be corrupt or you don't have the permissions.");
     }
 
     return romFileName;

--- a/src/frontend/qt_sdl/main.h
+++ b/src/frontend/qt_sdl/main.h
@@ -177,8 +177,6 @@ public:
     bool hasOGL;
     QOpenGLContext* getOGLContext();
 
-    static QString pickAndExtractFileFromArchive(QString archiveFileName, QByteArray *romBuffer);
-
 protected:
     void resizeEvent(QResizeEvent* event) override;
 
@@ -246,6 +244,8 @@ private:
     void updateRecentFilesMenu();
     void loadROM(QString filename);
     void loadROM(QByteArray *romData, QString archiveFileName, QString romFileName);
+
+    QString pickAndExtractFileFromArchive(QString archiveFileName, QByteArray *romBuffer);
 
     void createScreenPanel();
 

--- a/src/frontend/qt_sdl/main.h
+++ b/src/frontend/qt_sdl/main.h
@@ -177,7 +177,7 @@ public:
     bool hasOGL;
     QOpenGLContext* getOGLContext();
 
-    QString pickAndExtractFileFromArchive(QString archiveFileName, QByteArray *romBuffer);
+    static QString pickAndExtractFileFromArchive(QString archiveFileName, QByteArray *romBuffer);
 
 protected:
     void resizeEvent(QResizeEvent* event) override;

--- a/src/frontend/qt_sdl/main.h
+++ b/src/frontend/qt_sdl/main.h
@@ -243,6 +243,7 @@ private:
     QMenu *recentMenu;
     void updateRecentFilesMenu();
     void loadROM(QString filename);
+    void loadROM(QByteArray *romData, QString archiveFileName, QString romFileName);
 
     void createScreenPanel();
 

--- a/src/frontend/qt_sdl/main.h
+++ b/src/frontend/qt_sdl/main.h
@@ -177,6 +177,8 @@ public:
     bool hasOGL;
     QOpenGLContext* getOGLContext();
 
+    QString pickAndExtractFileFromArchive(QString archiveFileName, QByteArray *romBuffer);
+
 protected:
     void resizeEvent(QResizeEvent* event) override;
 


### PR DESCRIPTION
~~1. Fix directory path when extracting from archive~~
~~1.1.  Don't create new dir in execution dir of melonds~~
~~1.2.  Create it beside the archive instead~~

2. ArchiveUtil : Use QT functions for I/O
~~2.1.  Fixes permission related crash on linux~~
2.2.  Cleaner, platform independent

TODO:

- [x] Extract ROMs directly to RAM
- [x] Integrate archive support with Recent Files menu
- [x] Ensure GBA ROMs also load from archives
- [x] Fix Frontend stuff (Reset, drag-n-drop etc.)
- [x] Error handling
- [x] Save state file names when loading from archives