### PR TITLE
Don't save the window size to the config if in full screen

### DIFF
--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -1340,8 +1340,11 @@ void MainWindow::resizeEvent(QResizeEvent* event)
     int w = event->size().width();
     int h = event->size().height();
 
-    Config::WindowWidth = w;
-    Config::WindowHeight = h;
+    if (mainWindow != nullptr && !mainWindow->isFullScreen())
+    {
+        Config::WindowWidth = w;
+        Config::WindowHeight = h;
+    }
 
     // TODO: detect when the window gets maximized!
 }


### PR DESCRIPTION
If the emulator is quit while in fullscreen mode, the fullscreen window size will be saved to the config, overwriting whatever is set for window size, this commit changes it so window size is not saved when in fullscreen.