### PR TITLE
quit on sigint

### DIFF
--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -1024,7 +1024,8 @@ void ScreenPanelGL::onScreenLayoutChanged()
 static int signalFd[2];
 QSocketNotifier *signalSn;
 
-static void signalHandler(int) {
+static void signalHandler(int)
+{
     char a = 1;
     write(signalFd[0], &a, sizeof(a));
 }
@@ -1033,7 +1034,8 @@ static void signalHandler(int) {
 MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
 {
 #ifndef _WIN32
-    if (::socketpair(AF_UNIX, SOCK_STREAM, 0, signalFd)) {
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, signalFd))
+    {
        qFatal("Couldn't create socketpair");
     }
 


### PR DESCRIPTION
Since the emulator can be launched from the terminal, it'd be nice to be able to close it with CTRL+C.

It's not safe to quit from the signal handler itself, so this uses a QSocketNotifier which is the [qt recommended approach](https://doc.qt.io/qt-5/unix-signals.html).