### PR TITLE
Change all mentions of qt5 to qt@5 on macOS

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Install dependencies
       working-directory: ${{runner.workspace}}
       run: |
+        rm -rf /usr/local/bin/2to3 # Temporary workaround suggested here - https://github.com/actions/virtual-environments/issues/2322#issuecomment-749211076
         brew update
         brew install cmake sdl2 qt@5 libslirp libarchive
     - name: Create build environment

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         rm -rf /usr/local/bin/2to3 # Temporary workaround suggested here - https://github.com/actions/virtual-environments/issues/2322#issuecomment-749211076
         brew update
-        brew install cmake sdl2 qt@5 libslirp libarchive
+        brew install sdl2 qt@5 libslirp libarchive
     - name: Create build environment
       run: mkdir ${{runner.workspace}}/build
     - name: Configure

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -21,7 +21,8 @@ jobs:
     - name: Install dependencies
       working-directory: ${{runner.workspace}}
       run: |
-        brew install cmake sdl2 qt5 libslirp libarchive
+        brew update
+        brew install cmake sdl2 qt@5 libslirp libarchive
     - name: Create build environment
       run: mkdir ${{runner.workspace}}/build
     - name: Configure

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ If everything went well, melonDS should now be in the `dist` folder.
 
 ### macOS:
 1. Install the [Homebrew Package Manager](https://brew.sh)
-2. Install dependencies: `brew install git pkg-config cmake sdl2 qt5 libslirp libarchive`
+2. Install dependencies: `brew install git pkg-config cmake sdl2 qt@5 libslirp libarchive`
 3. Compile:
    ```zsh
    git clone https://github.com/Arisotura/melonDS.git


### PR DESCRIPTION
`brew install qt` will soon install Qt 6.
This is why a new `qt@5` alias has been created.
They recommend changing all `qt5` references to `qt@5`.
Reference: https://github.com/Homebrew/homebrew-core/pull/68241