### PR TITLE
Also include Homebrew on ARM64 Mac location in CMake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -101,8 +101,8 @@ if (ENABLE_JIT)
 endif()
 
 if (APPLE)
-        target_include_directories(core PUBLIC /usr/local/include)
-        target_link_directories(core PUBLIC /usr/local/lib)
+        target_include_directories(core PUBLIC /usr/local/include /opt/homebrew/include)
+        target_link_directories(core PUBLIC /usr/local/lib /opt/homebrew/lib)
 endif()
 
 if (ENABLE_OGLRENDERER)


### PR DESCRIPTION
This includes the Homebrew `include` and `lib` on macOS ARM64.
This PR was a request from @StLouisCPhT (they are not that experienced with Git so they asked me to do it).