### PR TITLE
Update CRC32 table to compile-time generation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(core)
 
-set (CMAKE_CXX_STANDARD 14)
+set (CMAKE_CXX_STANDARD 17)
 
 add_library(core STATIC
 	ARCodeFile.cpp

--- a/src/CRC32.h
+++ b/src/CRC32.h
@@ -16,11 +16,11 @@
     with melonDS. If not, see http://www.gnu.org/licenses/.
 */
 
-#ifndef CRC32_H
-#define CRC32_H
+#pragma once
 
 #include "types.h"
+#include <cstddef>
 
-u32 CRC32(u8* data, int len);
+// Calculates CRC-32 checksum using the polynomial 0x04C11DB7(0xEDB88320)
 
-#endif // CRC32_H
+u32 CRC32(const u8* data, size_t len);

--- a/src/NDSCart.cpp
+++ b/src/NDSCart.cpp
@@ -21,6 +21,7 @@
 #include "NDS.h"
 #include "DSi.h"
 #include "NDSCart.h"
+#include "CRC32.h"
 #include "ARM.h"
 #include "DSi_AES.h"
 #include "Platform.h"
@@ -479,6 +480,7 @@ u8 TransferCmd[8];
 bool CartInserted;
 u8* CartROM;
 u32 CartROMSize;
+u32 CartCRC;
 u32 CartID;
 bool CartIsHomebrew;
 bool CartIsDSi;
@@ -929,6 +931,8 @@ bool LoadROMCommon(u32 filelength, const char *sram, bool direct)
         CartID |= 0x40000000;
 
     printf("Cart ID: %08X\n", CartID);
+    CartCRC = CRC32(CartROM, CartROMSize);
+    printf("ROM CRC32: %08X\n", CartCRC);
 
     u32 arm9base = *(u32*)&CartROM[0x20];
 

--- a/src/NDSCart.h
+++ b/src/NDSCart.h
@@ -35,6 +35,7 @@ extern u8 EncSeed1[5];
 
 extern u8* CartROM;
 extern u32 CartROMSize;
+extern u32 CartCRC;
 
 extern u32 CartID;
 


### PR DESCRIPTION
This is an update to the CRC32 implementation to use a compile-time
generated CRC32 table rather than a run-time generated table protected
with a boolean.

Using `constexpr`, the table is guaranteed to be created statically using
C++17 features(will re-base once https://github.com/Arisotura/melonDS/pull/990 gets merged in).

Verified that the tables are statically generated across GCC, Clang, and MSVC:
https://godbolt.org/z/75Ta77

Verified CRCs are consistent with the previous implementation

This is based on code from another project of mines to reduce runtime load.
https://github.com/Wunkolo/qCheck