### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug report
+about: Tech support does not belong here. You should only file an issue here if you think you have experienced an actual bug.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!-- ⚠⚠ Do not delete this issue template! ⚠⚠ -->
+
+### Prerequisites
+
+<!-- Check the appropriate boxes before you submit your issue -->
+
+- [ ] I performed a cursory search of the issue tracker to avoid opening a duplicate issue
+    - Your issue may already be reported.
+- [ ] I have tried using workflow builds and confirm that the issue is still present on the latest commit *at the time of opening this report*.
+    - Bugs that are present in stable builds may have already been fixed in a recent commit. Conversely recent commits may have introduced bugs.
+- [ ] I have checked that this differs from the behavior of an actual DS/DSi
+
+### Describe the bug
+<!-- A clear and concise description of what the bug is. -->
+
+### How to reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+### Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
+
+### Screenshots
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+### System Information
+ - OS: <!-- e.g. Windows 20H2 -->
+ - Commit / Version: <!-- e.g.  2502c8d / 0.9.1 -->
+
+### Additional context
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Feature Request] Insert title"
+labels: 'enhancement'
+assignees: ''
+
+---
+
+<!-- Detail your request here: -->
+
+
+### Is your feature request related to a problem?
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+### Additional context
+<!-- Add any other context or screenshots about the feature request here. -->


### PR DESCRIPTION
There are often a lot of inconsistencies in regards to how issues are laid out.

I hope the addition of an issue template would help reduce those inconsistencies.

Predominantly built on the example issue template from Github.
Inspiration taken from Citra, Darkreader, Ublock Origin.