### PR TITLE
Fix edge case in the division engine, fix edge case in the CPU

### DIFF
--- a/src/ARMInterpreter_ALU.cpp
+++ b/src/ARMInterpreter_ALU.cpp
@@ -290,7 +290,7 @@ void A_##x##_REG_ROR_REG(ARM* cpu) \
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(res & ~3); \
+        cpu->JumpTo(res & ~1); \
     } \
     else \
     { \
@@ -321,7 +321,7 @@ A_IMPLEMENT_ALU_OP(AND,_S)
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(res & ~3); \
+        cpu->JumpTo(res & ~1); \
     } \
     else \
     { \
@@ -352,7 +352,7 @@ A_IMPLEMENT_ALU_OP(EOR,_S)
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(res & ~3); \
+        cpu->JumpTo(res & ~1); \
     } \
     else \
     { \
@@ -385,7 +385,7 @@ A_IMPLEMENT_ALU_OP(SUB,)
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(res & ~3); \
+        cpu->JumpTo(res & ~1); \
     } \
     else \
     { \
@@ -418,7 +418,7 @@ A_IMPLEMENT_ALU_OP(RSB,)
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(res & ~3); \
+        cpu->JumpTo(res & ~1); \
     } \
     else \
     { \
@@ -451,7 +451,7 @@ A_IMPLEMENT_ALU_OP(ADD,)
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(res & ~3); \
+        cpu->JumpTo(res & ~1); \
     } \
     else \
     { \
@@ -486,7 +486,7 @@ A_IMPLEMENT_ALU_OP(ADC,)
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(res & ~3); \
+        cpu->JumpTo(res & ~1); \
     } \
     else \
     { \
@@ -521,7 +521,7 @@ A_IMPLEMENT_ALU_OP(SBC,)
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(res & ~3); \
+        cpu->JumpTo(res & ~1); \
     } \
     else \
     { \
@@ -600,7 +600,7 @@ A_IMPLEMENT_ALU_TEST(CMN,)
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(res & ~3); \
+        cpu->JumpTo(res & ~1); \
     } \
     else \
     { \
@@ -629,7 +629,7 @@ A_IMPLEMENT_ALU_OP(ORR,_S)
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(b & ~3); \
+        cpu->JumpTo(b & ~1); \
     } \
     else \
     { \
@@ -673,7 +673,7 @@ void A_MOV_REG_LSL_IMM_DBG(ARM* cpu)
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(res & ~3); \
+        cpu->JumpTo(res & ~1); \
     } \
     else \
     { \
@@ -703,7 +703,7 @@ A_IMPLEMENT_ALU_OP(BIC,_S)
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(b & ~3); \
+        cpu->JumpTo(b & ~1); \
     } \
     else \
     { \

--- a/src/ARMInterpreter_ALU.cpp
+++ b/src/ARMInterpreter_ALU.cpp
@@ -290,7 +290,7 @@ void A_##x##_REG_ROR_REG(ARM* cpu) \
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(res); \
+        cpu->JumpTo(res & ~3); \
     } \
     else \
     { \
@@ -321,7 +321,7 @@ A_IMPLEMENT_ALU_OP(AND,_S)
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(res); \
+        cpu->JumpTo(res & ~3); \
     } \
     else \
     { \
@@ -352,7 +352,7 @@ A_IMPLEMENT_ALU_OP(EOR,_S)
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(res); \
+        cpu->JumpTo(res & ~3); \
     } \
     else \
     { \
@@ -385,7 +385,7 @@ A_IMPLEMENT_ALU_OP(SUB,)
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(res); \
+        cpu->JumpTo(res & ~3); \
     } \
     else \
     { \
@@ -418,7 +418,7 @@ A_IMPLEMENT_ALU_OP(RSB,)
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(res); \
+        cpu->JumpTo(res & ~3); \
     } \
     else \
     { \
@@ -451,7 +451,7 @@ A_IMPLEMENT_ALU_OP(ADD,)
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(res); \
+        cpu->JumpTo(res & ~3); \
     } \
     else \
     { \
@@ -486,7 +486,7 @@ A_IMPLEMENT_ALU_OP(ADC,)
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(res); \
+        cpu->JumpTo(res & ~3); \
     } \
     else \
     { \
@@ -521,7 +521,7 @@ A_IMPLEMENT_ALU_OP(SBC,)
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(res); \
+        cpu->JumpTo(res & ~3); \
     } \
     else \
     { \
@@ -600,7 +600,7 @@ A_IMPLEMENT_ALU_TEST(CMN,)
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(res); \
+        cpu->JumpTo(res & ~3); \
     } \
     else \
     { \
@@ -629,7 +629,7 @@ A_IMPLEMENT_ALU_OP(ORR,_S)
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(b); \
+        cpu->JumpTo(b & ~3); \
     } \
     else \
     { \
@@ -673,7 +673,7 @@ void A_MOV_REG_LSL_IMM_DBG(ARM* cpu)
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(res); \
+        cpu->JumpTo(res & ~3); \
     } \
     else \
     { \
@@ -703,7 +703,7 @@ A_IMPLEMENT_ALU_OP(BIC,_S)
     if (c) cpu->AddCycles_CI(c); else cpu->AddCycles_C(); \
     if (((cpu->CurInstr>>12) & 0xF) == 15) \
     { \
-        cpu->JumpTo(b); \
+        cpu->JumpTo(b & ~3); \
     } \
     else \
     { \

--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -1758,6 +1758,7 @@ void DivDone(u32 param)
             else if (num == -0x8000000000000000 && den == -1)
             {
                 *(s64*)&DivQuotient[0] = 0x8000000000000000;
+                *(s64*)&DivRemainder[0] = 0;
             }
             else
             {
@@ -1779,6 +1780,7 @@ void DivDone(u32 param)
             else if (num == -0x8000000000000000 && den == -1)
             {
                 *(s64*)&DivQuotient[0] = 0x8000000000000000;
+                *(s64*)&DivRemainder[0] = 0;
             }
             else
             {


### PR DESCRIPTION
Both of these fix part of this test ROM: https://github.com/RockPolish/rockwrestler
(Look at the math engine tests, and the last test of the CPU section)

Fixed bugs:
    - Division with INT64_MIN as dividend and -1 as divisor should give a remainder of 0 (look at the test ROM)
    - Certain ALU ops such as MOV were able to switch to Thumb mode. To fix this I made it so the address gets force aligned. Didn't fix the ALU ops with the S bit on yet because they're a bit more complicated