### PR TITLE
Fix OpenGL display scaling on high DPI

### DIFF
--- a/src/frontend/qt_sdl/OSD.cpp
+++ b/src/frontend/qt_sdl/OSD.cpp
@@ -59,6 +59,7 @@ std::deque<Item> ItemQueue;
 
 QOpenGLShaderProgram* Shader;
 GLint uScreenSize, uOSDPos, uOSDSize;
+GLfloat uScaleFactor;
 GLuint OSDVertexArray;
 GLuint OSDVertexBuffer;
 
@@ -86,6 +87,7 @@ bool Init(QOpenGLFunctions_3_2_Core* f)
         uScreenSize = Shader->uniformLocation("uScreenSize");
         uOSDPos = Shader->uniformLocation("uOSDPos");
         uOSDSize = Shader->uniformLocation("uOSDSize");
+        uScaleFactor = Shader->uniformLocation("uScaleFactor");
 
         float vertices[6*2] =
         {
@@ -430,6 +432,7 @@ void DrawGL(QOpenGLFunctions_3_2_Core* f, float w, float h)
     Shader->bind();
 
     f->glUniform2f(uScreenSize, w, h);
+    f->glUniform1f(uScaleFactor, mainWindow->devicePixelRatioF());
 
     f->glBindBuffer(GL_ARRAY_BUFFER, OSDVertexBuffer);
     f->glBindVertexArray(OSDVertexArray);

--- a/src/frontend/qt_sdl/OSD_shaders.h
+++ b/src/frontend/qt_sdl/OSD_shaders.h
@@ -25,6 +25,7 @@ uniform vec2 uScreenSize;
 
 uniform ivec2 uOSDPos;
 uniform ivec2 uOSDSize;
+uniform float uScaleFactor;
 
 in vec2 vPosition;
 
@@ -34,11 +35,11 @@ void main()
 {
     vec4 fpos;
 
-    vec2 osdpos = (vPosition * vec2(uOSDSize));
+    vec2 osdpos = (vPosition * vec2(uOSDSize * uScaleFactor));
     fTexcoord = osdpos;
     osdpos += uOSDPos;
 
-    fpos.xy = ((osdpos * 2.0) / uScreenSize) - 1.0;
+    fpos.xy = ((osdpos * 2.0) / uScreenSize * uScaleFactor) - 1.0;
     fpos.y *= -1;
     fpos.z = 0.0;
     fpos.w = 1.0;

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -1004,7 +1004,8 @@ void ScreenPanelGL::paintGL()
     {
         screenShader->bind();
 
-        screenShader->setUniformValue("uScreenSize", (float)w*factor, (float)h*factor);
+        screenShader->setUniformValue("uScreenSize", (float)w, (float)h);
+	screenShader->setUniformValue("uScaleFactor", factor);
 
         emuThread->FrontBufferLock.lock();
         int frontbuf = emuThread->FrontBuffer;

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -1005,7 +1005,7 @@ void ScreenPanelGL::paintGL()
         screenShader->bind();
 
         screenShader->setUniformValue("uScreenSize", (float)w, (float)h);
-	screenShader->setUniformValue("uScaleFactor", factor);
+        screenShader->setUniformValue("uScaleFactor", factor);
 
         emuThread->FrontBufferLock.lock();
         int frontbuf = emuThread->FrontBuffer;

--- a/src/frontend/qt_sdl/main_shaders.h
+++ b/src/frontend/qt_sdl/main_shaders.h
@@ -23,6 +23,7 @@ const char* kScreenVS = R"(#version 140
 
 uniform vec2 uScreenSize;
 uniform mat2x3 uTransform;
+uniform float uScaleFactor;
 
 in vec2 vPosition;
 in vec2 vTexcoord;
@@ -33,9 +34,9 @@ void main()
 {
     vec4 fpos;
 
-    fpos.xy = vec3(vPosition, 1.0) * uTransform;
+    fpos.xy = vec3(vPosition, 1.0) * uTransform * uScaleFactor;
 
-    fpos.xy = ((fpos.xy * 2.0) / uScreenSize) - 1.0;
+    fpos.xy = ((fpos.xy * 2.0) / (uScreenSize * uScaleFactor)) - 1.0;
     fpos.y *= -1;
     fpos.z = 0.0;
     fpos.w = 1.0;


### PR DESCRIPTION
This fixes the issue where the screens were being shown too small in the top left of the window if using OpenGL display on a high-DPI monitor because not all of the values in the shader were being scaled.