### PR TITLE
Require alt key for menu shortcuts (Prevents conflicts with control inputs)

### DIFF
--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -1130,7 +1130,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
 
     QMenuBar* menubar = new QMenuBar();
     {
-        QMenu* menu = menubar->addMenu("File");
+        QMenu* menu = menubar->addMenu("&File");
 
         actOpenROM = menu->addAction("Open ROM...");
         connect(actOpenROM, &QAction::triggered, this, &MainWindow::onOpenFile);
@@ -1198,7 +1198,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
         connect(actQuit, &QAction::triggered, this, &MainWindow::onQuit);
     }
     {
-        QMenu* menu = menubar->addMenu("System");
+        QMenu* menu = menubar->addMenu("&System");
 
         actPause = menu->addAction("Pause");
         actPause->setCheckable(true);
@@ -1220,7 +1220,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
         connect(actSetupCheats, &QAction::triggered, this, &MainWindow::onSetupCheats);
     }
     {
-        QMenu* menu = menubar->addMenu("Config");
+        QMenu* menu = menubar->addMenu("&Config");
 
         actEmuSettings = menu->addAction("Emu settings");
         connect(actEmuSettings, &QAction::triggered, this, &MainWindow::onOpenEmuSettings);


### PR DESCRIPTION
Currently on Debian(possibly others, I am unable to test those), if one is to use (for example) WASD for directional controls, pressing S will cause the "System" menu to become focused. The same is true if using "F" or "C" for a input.
QT, by default, will automatically assign a hot key based off the first available letter in the menu text. By prepending a ampersand([Ref](https://doc.qt.io/qt-5/qmenubar.html#details)), this puts it behind the "Alt" key which is common in many applications.
I figured that since that the Alt key cannot be bound in combination of other keys, such as Alt+F for "B", that putting these behind alt key would be a sufficient fix.