### PR TITLE
Savestate: use Platform::OpenLocalFile

### DIFF
--- a/src/Savestate.cpp
+++ b/src/Savestate.cpp
@@ -52,7 +52,7 @@ Savestate::Savestate(const char* filename, bool save)
     if (save)
     {
         Saving = true;
-        file = Platform::OpenFile(filename, "wb");
+        file = Platform::OpenLocalFile(filename, "wb");
         if (!file)
         {
             printf("savestate: file %s doesn't exist\n", filename);


### PR DESCRIPTION
Closes #1025 

When `"timewarp.mln"` gets passed in as filename, `OpenLocalFile` will see it's not an absolute path, so it will place it in the config directory.

Prior to this change, it gets written to whatever working directory you are in when melonDS is launched, usually `~`.