### PR TITLE
Pass filename to program in desktop entry

### DIFF
--- a/net.kuribo64.melonDS.desktop
+++ b/net.kuribo64.melonDS.desktop
@@ -2,7 +2,7 @@
 Name=melonDS
 GenericName=Nintendo DS Emulator
 Comment=A fast and accurate Nintendo DS emulator.
-Exec=melonDS
+Exec=melonDS %f
 Type=Application
 Categories=Game;Emulator;
 Terminal=false


### PR DESCRIPTION
The desktop entry was already configured to handle DS rom file types, but the filename of such a rom was not passed to the program itself. The `%f` passes a single local filename to the program to handle these and allow to use the *open with* menu with melonDS.