### PR TITLE
Use 256x256 instead of 32x32 as window icon size

### DIFF
--- a/melon.qrc
+++ b/melon.qrc
@@ -1,6 +1,6 @@
 <!DOCTYPE RCC>
 <RCC version="1.0">
 	<qresource>
-		<file alias="melon-icon">icon/melon_32x32.png</file>
+		<file alias="melon-icon">icon/melon_256x256.png</file>
 	</qresource>
 </RCC>


### PR DESCRIPTION
Pass the 256x256 icon to Qt to use as the window icon instead of the 32x32 version. Fixes #1113