### PR TITLE
Partial support for remembering last launched full screen mode.

### DIFF
--- a/src/frontend/qt_sdl/PlatformConfig.cpp
+++ b/src/frontend/qt_sdl/PlatformConfig.cpp
@@ -35,6 +35,7 @@ int JoystickID;
 int WindowWidth;
 int WindowHeight;
 int WindowMaximized;
+int WindowFullScreen;
 
 int ScreenRotation;
 int ScreenGap;
@@ -143,6 +144,7 @@ ConfigEntry PlatformConfigFile[] =
     {"WindowWidth",  0, &WindowWidth,  256, NULL, 0},
     {"WindowHeight", 0, &WindowHeight, 384, NULL, 0},
     {"WindowMax",    0, &WindowMaximized, 0, NULL, 0},
+    {"WindowFullScreen",   0, &WindowFullScreen, 0, NULL, 0},
 
     {"ScreenRotation", 0, &ScreenRotation, 0, NULL, 0},
     {"ScreenGap",      0, &ScreenGap,      0, NULL, 0},

--- a/src/frontend/qt_sdl/PlatformConfig.h
+++ b/src/frontend/qt_sdl/PlatformConfig.h
@@ -51,6 +51,7 @@ extern int JoystickID;
 extern int WindowWidth;
 extern int WindowHeight;
 extern int WindowMaximized;
+extern int WindowFullScreen;
 
 extern int ScreenRotation;
 extern int ScreenGap;

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -1505,7 +1505,15 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
     }
     setMenuBar(menubar);
 
+    // Even if full screen was saved, call resize to save default width and height.
+    // That way when user inits in fullscreen and un-fullscreens the window, they'll get
+    // those dimensions back.
     resize(Config::WindowWidth, Config::WindowHeight);
+    if (Config::WindowFullScreen)
+    {
+        showFullScreen();
+        menuBar()->setFixedHeight(0); // Don't use hide() as menubar actions stop working
+    }
 
     show();
     createScreenPanel();
@@ -1619,13 +1627,17 @@ void MainWindow::resizeEvent(QResizeEvent* event)
     int w = event->size().width();
     int h = event->size().height();
 
-    if (mainWindow != nullptr && !mainWindow->isFullScreen())
+    if (mainWindow == nullptr) return;
+
+    // FIXME: macOS: if full screen is launched via the native full screen
+    // window button, QT's isFullScreen returns false.
+    Config::WindowFullScreen = mainWindow->isFullScreen();
+
+    if (!Config::WindowFullScreen)
     {
         Config::WindowWidth = w;
         Config::WindowHeight = h;
     }
-
-    // TODO: detect when the window gets maximized!
 }
 
 void MainWindow::keyPressEvent(QKeyEvent* event)


### PR DESCRIPTION
This patch only works for toggling full screen via the hotkey. For
some reason, QT's isFullScreen is false if you go from not full screen
to full screen via the green macOS window button.

Tested the following on macOS (hotkey means configured hotkey for full screen):

-- Working cases:
* launch, quit, launch. Result: not full screen.
* launch, hotkey, quit, launch. Result: full screen.
* launch, hotkey, hotkey, quit, launch. Result: not full screen.
* launch, resize, hotkey, quit, launch (Result: full screen), hotkey.
  Result: not full screen with previously resized window size.

-- Not working cases (mouse means mouse click on green macOS window button):
* launch, mouse, quit, launch. Incorrect result: not full screen.
* launch, hotkey, mouse, quit, launch. Incorrect result: full screen.
