### PR TITLE
Make building with libslirp optional

### DIFF
--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -12,7 +12,6 @@ SET(SOURCES_QT_SDL
     InterfaceSettingsDialog.cpp
     Input.cpp
     LAN_PCap.cpp
-    LAN_Socket.cpp
     OSD.cpp
     OSD_shaders.h
     font.h
@@ -70,9 +69,15 @@ find_package(Threads REQUIRED)
 find_package(PkgConfig REQUIRED)
 find_package(Iconv REQUIRED)
 pkg_check_modules(SDL2 REQUIRED sdl2)
-pkg_check_modules(SLIRP REQUIRED slirp)
+pkg_check_modules(SLIRP slirp)
 pkg_check_modules(LIBARCHIVE REQUIRED libarchive)
 add_compile_definitions(ARCHIVE_SUPPORT_ENABLED)
+
+if (SLIRP_FOUND)
+    option(ENABLE_LIBSLIRP "Enable use of libslirp for network sockets" ON)
+else()
+    option(ENABLE_LIBSLIRP "Enable use of libslirp for network sockets" OFF)
+endif()
 
 if (WIN32 AND (CMAKE_BUILD_TYPE STREQUAL Release))
     add_executable(melonDS WIN32 ${SOURCES_QT_SDL})
@@ -80,11 +85,25 @@ else()
     add_executable(melonDS ${SOURCES_QT_SDL})
 endif()
 
+if (ENABLE_LIBSLIRP)
+	target_compile_definitions(melonDS PRIVATE -DHAVE_LIBSLIRP)
+    target_sources(melonDS PRIVATE LAN_Socket.cpp)
+endif()
+
 target_link_libraries(melonDS ${CMAKE_THREAD_LIBS_INIT})
 
-target_include_directories(melonDS PRIVATE ${SDL2_INCLUDE_DIRS} ${SDL2_PREFIX}/include ${SLIRP_INCLUDE_DIRS} ${LIBARCHIVE_INCLUDE_DIRS})
-target_link_directories(melonDS PRIVATE ${SDL2_LIBRARY_DIRS} ${SLIRP_LIBRARY_DIRS})
-target_link_directories(melonDS PRIVATE ${LIBARCHIVE_LIBRARY_DIRS})
+target_include_directories(
+    melonDS PRIVATE
+    ${SDL2_INCLUDE_DIRS} ${SDL2_PREFIX}/include
+    ${SLIRP_INCLUDE_DIRS}
+    ${LIBARCHIVE_INCLUDE_DIRS}
+)
+target_link_directories(
+    melonDS PRIVATE
+    ${SDL2_LIBRARY_DIRS}
+    ${SLIRP_LIBRARY_DIRS}
+    ${LIBARCHIVE_LIBRARY_DIRS}
+)
 
 target_include_directories(melonDS PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(melonDS PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/..")

--- a/src/frontend/qt_sdl/Platform.cpp
+++ b/src/frontend/qt_sdl/Platform.cpp
@@ -51,7 +51,11 @@
 
 #include "Platform.h"
 #include "PlatformConfig.h"
+
+#ifdef HAVE_LIBSLIRP
 #include "LAN_Socket.h"
+#endif
+
 #include "LAN_PCap.h"
 #include <string>
 
@@ -393,6 +397,7 @@ int MP_RecvPacket(u8* data, bool block)
 
 
 
+#ifdef HAVE_LIBSLIRP
 bool LAN_Init()
 {
     if (Config::DirectLAN)
@@ -408,6 +413,12 @@ bool LAN_Init()
 
     return true;
 }
+#else
+bool LAN_Init()
+{
+    return LAN_PCap::Init(true);
+}
+#endif
 
 void LAN_DeInit()
 {
@@ -417,9 +428,12 @@ void LAN_DeInit()
     //else
     //    LAN_Socket::DeInit();
     LAN_PCap::DeInit();
+#ifdef HAVE_LIBSLIRP
     LAN_Socket::DeInit();
+#endif
 }
 
+#ifdef HAVE_LIBSLIRP
 int LAN_SendPacket(u8* data, int len)
 {
     if (Config::DirectLAN)
@@ -435,6 +449,17 @@ int LAN_RecvPacket(u8* data)
     else
         return LAN_Socket::RecvPacket(data);
 }
+#else
+int LAN_SendPacket(u8* data, int len)
+{
+    return LAN_PCap::SendPacket(data, len);
+}
+
+int LAN_RecvPacket(u8* data)
+{
+    return LAN_PCap::RecvPacket(data);
+}
+#endif
 
 void Sleep(u64 usecs)
 {

--- a/src/frontend/qt_sdl/WifiSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/WifiSettingsDialog.cpp
@@ -51,7 +51,9 @@ WifiSettingsDialog::WifiSettingsDialog(QWidget* parent) : QDialog(parent), ui(ne
     ui->setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose);
 
+#ifdef HAVE_LIBSLIRP
     LAN_Socket::Init();
+#endif
     haspcap = LAN_PCap::Init(false);
 
     ui->rbDirectMode->setText("Direct mode (requires " PCAP_NAME " and ethernet connection)");
@@ -71,8 +73,14 @@ WifiSettingsDialog::WifiSettingsDialog(QWidget* parent) : QDialog(parent), ui(ne
     }
     ui->cbxDirectAdapter->setCurrentIndex(sel);
 
+#ifdef HAVE_LIBSLIRP
     ui->rbDirectMode->setChecked(Config::DirectLAN != 0);
     ui->rbIndirectMode->setChecked(Config::DirectLAN == 0);
+#else
+    ui->rbDirectMode->setChecked(true);
+    ui->rbIndirectMode->setEnabled(false);
+    ui->rbIndirectMode->setText("Indirect mode (unavailable, compiled without libslirp)");
+#endif
     if (!haspcap) ui->rbDirectMode->setEnabled(false);
 
     updateAdapterControls();


### PR DESCRIPTION
This commit makes building using libslirp optional and disables indirect mode in the GUI if libslirp was not found. Currently required to build on some platforms that do not have libslirp, such as FreeBSD.