### PR TITLE
Fallback to backup DSi Footer in NAND Image

### DIFF
--- a/src/DSi.cpp
+++ b/src/DSi.cpp
@@ -457,15 +457,23 @@ bool LoadNAND()
         fread(nand_footer, 1, 16, SDMMCFile);
         if (memcmp(nand_footer, nand_footer_ref, 16))
         {
-            printf("ERROR: NAND missing nocash footer\n");
-            return false;
+            // There is another copy of the footer at 000FF800h for the case
+            // that by external tools the image was cut off 
+            // See https://problemkaputt.de/gbatek.htm#dsisdmmcimages
+            fseek(SDMMCFile, 0x000FF800, SEEK_SET) ;
+            fread(nand_footer, 1, 16, SDMMCFile);
+            if (memcmp(nand_footer, nand_footer_ref, 16))
+            {
+              printf("ERROR: NAND missing nocash footer\n");
+              return false;
+            }
         }
 
         fread(eMMC_CID, 1, 16, SDMMCFile);
         fread(&ConsoleID, 1, 8, SDMMCFile);
 
         printf("eMMC CID: "); printhex(eMMC_CID, 16);
-        printf("Console ID: %" PRIu64 "\n", ConsoleID);
+        printf("Console ID: %" PRIx64 "\n", ConsoleID);
     }
 
     memset(ITCMInit, 0, 0x8000);

--- a/src/DSi.cpp
+++ b/src/DSi.cpp
@@ -460,7 +460,7 @@ bool LoadNAND()
             // There is another copy of the footer at 000FF800h for the case
             // that by external tools the image was cut off 
             // See https://problemkaputt.de/gbatek.htm#dsisdmmcimages
-            fseek(SDMMCFile, 0x000FF800, SEEK_SET) ;
+            fseek(SDMMCFile, 0x000FF800, SEEK_SET);
             fread(nand_footer, 1, 16, SDMMCFile);
             if (memcmp(nand_footer, nand_footer_ref, 16))
             {


### PR DESCRIPTION
DSi MMC image loading now uses to the backup of the DSi Footer, if the footer at end of the file is absent or corrupted.
Changes output format of the ConsoleID to be consistent with all other tools (PRIx64 instead of PRIu64)