### PR TITLE
Fix Deadlock on unlaunch starting apps, when using software renderer

### DIFF
--- a/src/GPU3D_Soft.cpp
+++ b/src/GPU3D_Soft.cpp
@@ -1646,7 +1646,7 @@ void SoftRenderer::RenderPolygons(bool threaded, Polygon** polygons, int npolys)
 
 void SoftRenderer::VCount144()
 {
-    if (RenderThreadRunning.load(std::memory_order_relaxed))
+    if (RenderThreadRunning.load(std::memory_order_relaxed) && RenderThreadRendering)
         Platform::Semaphore_Wait(Sema_RenderDone);
 }
 
@@ -1694,8 +1694,8 @@ void SoftRenderer::RenderThreadFunc()
             RenderPolygons(true, &RenderPolygonRAM[0], RenderNumPolygons);
         }
 
-        Platform::Semaphore_Post(Sema_RenderDone);
         RenderThreadRendering = false;
+        Platform::Semaphore_Post(Sema_RenderDone);
     }
 }
 


### PR DESCRIPTION
Fix for a possible deadlock where RenderDone is waited for while the renderer is not rendering and waiting for the RenderStart semaphore