### PR TITLE
SPU: Emulate SOUNDBIAS and 10-bit degrade

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -42,6 +42,7 @@ int DSiSDEnable;
 char DSiSDPath[1024];
 
 int RandomizeMAC;
+int AudioBitrate;
 
 #ifdef JIT_ENABLED
 int JIT_Enable = false;
@@ -67,6 +68,7 @@ ConfigEntry ConfigFile[] =
     {"DSiSDPath", 1, DSiSDPath, 0, "", 1023},
 
     {"RandomizeMAC", 0, &RandomizeMAC, 0, NULL, 0},
+    {"AudioBitrate", 0, &AudioBitrate, 0, NULL, 0},
 
 #ifdef JIT_ENABLED
     {"JIT_Enable", 0, &JIT_Enable, 0, NULL, 0},

--- a/src/Config.h
+++ b/src/Config.h
@@ -55,6 +55,7 @@ extern int DSiSDEnable;
 extern char DSiSDPath[1024];
 
 extern int RandomizeMAC;
+extern int AudioBitrate;
 
 #ifdef JIT_ENABLED
 extern int JIT_Enable;

--- a/src/NDS.cpp
+++ b/src/NDS.cpp
@@ -596,11 +596,24 @@ void Reset()
     RTC::Reset();
     Wifi::Reset();
 
+    // The SOUNDBIAS register does nothing on DSi
+    SPU::SetApplyBias(ConsoleType == 0);
+
+    bool degradeAudio = true;
+
     if (ConsoleType == 1)
     {
         DSi::Reset();
         KeyInput &= ~(1 << (16+6));
+        degradeAudio = false;
     }
+
+    if (Config::AudioBitrate == 1) // Always 10-bit
+        degradeAudio = true;
+    else if (Config::AudioBitrate == 2) // Always 16-bit
+        degradeAudio = false;
+
+    SPU::SetDegrade10Bit(degradeAudio);
 
     AREngine::Reset();
 }

--- a/src/SPU.cpp
+++ b/src/SPU.cpp
@@ -192,11 +192,13 @@ void SetBias(u16 bias)
     Bias = bias;
 }
 
-void SetApplyBias(bool enable) {
+void SetApplyBias(bool enable)
+{
     ApplyBias = enable;
 }
 
-void SetDegrade10Bit(bool enable) {
+void SetDegrade10Bit(bool enable)
+{
     Degrade10Bit = enable;
 }
 
@@ -803,7 +805,7 @@ void Mix(u32 dummy)
 
     // Add SOUNDBIAS value
     // The value used by all commercial games is 0x200, so we subtract that so it won't offset the final sound output.
-    if (ApplyBias == true)
+    if (ApplyBias)
     {
         leftoutput += (Bias << 6) - 0x8000;
         rightoutput += (Bias << 6) - 0x8000;

--- a/src/SPU.cpp
+++ b/src/SPU.cpp
@@ -799,9 +799,18 @@ void Mix(u32 dummy)
     rightoutput = ((s64)rightoutput * MasterVolume) >> 7;
 
     leftoutput >>= 8;
+    rightoutput >>= 8;
+
+    // Add SOUNDBIAS value
+    // The value used by all commercial games is 0x200, so we subtract that so it won't offset the final sound output.
+    if (ApplyBias == true)
+    {
+        leftoutput += (Bias << 6) - 0x8000;
+        rightoutput += (Bias << 6) - 0x8000;
+    }
+
     if      (leftoutput < -0x8000) leftoutput = -0x8000;
     else if (leftoutput > 0x7FFF)  leftoutput = 0x7FFF;
-    rightoutput >>= 8;
     if      (rightoutput < -0x8000) rightoutput = -0x8000;
     else if (rightoutput > 0x7FFF)  rightoutput = 0x7FFF;
 
@@ -810,14 +819,6 @@ void Mix(u32 dummy)
     {
         leftoutput &= 0xFFFFFFC0;
         rightoutput &= 0xFFFFFFC0;
-    }
-
-    // Add SOUNDBIAS value
-    // The value used by all commercial games is 0x200, so we subtract that so it won't offset the final sound output.
-    if (ApplyBias == true)
-    {
-        leftoutput += (Bias << 6) - 0x8000;
-        rightoutput += (Bias << 6) - 0x8000;
     }
 
     // OutputBufferFrame can never get full because it's

--- a/src/SPU.h
+++ b/src/SPU.h
@@ -35,6 +35,8 @@ void DoSavestate(Savestate* file);
 void SetInterpolation(int type);
 
 void SetBias(u16 bias);
+void SetDegrade10Bit(bool enable);
+void SetApplyBias(bool enable);
 
 void Mix(u32 dummy);
 

--- a/src/frontend/qt_sdl/AudioSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/AudioSettingsDialog.cpp
@@ -39,6 +39,7 @@ AudioSettingsDialog::AudioSettingsDialog(QWidget* parent) : QDialog(parent), ui(
     setAttribute(Qt::WA_DeleteOnClose);
 
     oldInterp = Config::AudioInterp;
+    oldBitrate = Config::AudioBitrate;
     oldVolume = Config::AudioVolume;
 
     ui->cbInterpolation->addItem("None");
@@ -46,6 +47,11 @@ AudioSettingsDialog::AudioSettingsDialog(QWidget* parent) : QDialog(parent), ui(
     ui->cbInterpolation->addItem("Cosine");
     ui->cbInterpolation->addItem("Cubic");
     ui->cbInterpolation->setCurrentIndex(Config::AudioInterp);
+
+    ui->cbBitrate->addItem("Automatic");
+    ui->cbBitrate->addItem("10-bit");
+    ui->cbBitrate->addItem("16-bit");
+    ui->cbBitrate->setCurrentIndex(Config::AudioBitrate);
 
     ui->slVolume->setValue(Config::AudioVolume);
 
@@ -81,9 +87,20 @@ void AudioSettingsDialog::on_AudioSettingsDialog_accepted()
 void AudioSettingsDialog::on_AudioSettingsDialog_rejected()
 {
     Config::AudioInterp = oldInterp;
+    Config::AudioBitrate = oldBitrate;
     Config::AudioVolume = oldVolume;
 
     closeDlg();
+}
+
+void AudioSettingsDialog::on_cbBitrate_currentIndexChanged(int idx)
+{
+    // prevent a spurious change
+    if (ui->cbBitrate->count() < 3) return;
+
+    Config::AudioBitrate = ui->cbBitrate->currentIndex();
+
+    emit updateAudioSettings();
 }
 
 void AudioSettingsDialog::on_cbInterpolation_currentIndexChanged(int idx)

--- a/src/frontend/qt_sdl/AudioSettingsDialog.h
+++ b/src/frontend/qt_sdl/AudioSettingsDialog.h
@@ -59,6 +59,7 @@ private slots:
     void on_AudioSettingsDialog_rejected();
 
     void on_cbInterpolation_currentIndexChanged(int idx);
+    void on_cbBitrate_currentIndexChanged(int idx);
     void on_slVolume_valueChanged(int val);
     void onChangeMicMode(int mode);
     void on_btnMicWavBrowse_clicked();
@@ -67,6 +68,7 @@ private:
     Ui::AudioSettingsDialog* ui;
 
     int oldInterp;
+    int oldBitrate;
     int oldVolume;
     QButtonGroup* grpMicMode;
 };

--- a/src/frontend/qt_sdl/AudioSettingsDialog.ui
+++ b/src/frontend/qt_sdl/AudioSettingsDialog.ui
@@ -29,14 +29,14 @@
       <string>Audio output</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="1" column="0">
+      <item row="2" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
          <string>Volume:</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <widget class="QSlider" name="slVolume">
         <property name="whatsThis">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Controls the volume of the audio output.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -63,6 +63,20 @@
        <widget class="QComboBox" name="cbInterpolation">
         <property name="whatsThis">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Applies interpolation to audio samples for better quality. Option &amp;quot;None&amp;quot; is accurate to DS hardware.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Bitrate:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="cbBitrate">
+        <property name="whatsThis">
+			<string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The bitrate of audio playback. If set to &quot;Automatic&quot; this will be 10-bit for DS mode and 16-bit for DSi mode.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
       </item>

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -2436,6 +2436,11 @@ void MainWindow::onOpenAudioSettings()
 void MainWindow::onUpdateAudioSettings()
 {
     SPU::SetInterpolation(Config::AudioInterp);
+
+    if (Config::AudioBitrate == 0)
+        SPU::SetDegrade10Bit(NDS::ConsoleType == 0);
+    else
+        SPU::SetDegrade10Bit(Config::AudioBitrate == 1);
 }
 
 void MainWindow::onAudioSettingsFinished(int res)


### PR DESCRIPTION
Also adds a config option to override the sound bitrate, defaulting to automatic based on model.

Needs more testing probably.