### PR TITLE
Misc fixes for dsiwifi BMI stage

### DIFF
--- a/src/DSi_NWifi.h
+++ b/src/DSi_NWifi.h
@@ -95,6 +95,20 @@ private:
         Mailbox[n].Write(val & 0xFF);
     }
 
+    u32 MB_Peek32(int n)
+    {
+        return MB_Peek32(n, 0);
+    }
+
+    u32 MB_Peek32(int n, int offs)
+    {
+        u32 ret = Mailbox[n].Peek(offs+0);
+        ret |= (Mailbox[n].Peek(offs+1) << 8);
+        ret |= (Mailbox[n].Peek(offs+2) << 16);
+        ret |= (Mailbox[n].Peek(offs+3) << 24);
+        return ret;
+    }
+
     u32 MB_Read32(int n)
     {
         u32 ret = Mailbox[n].Read();

--- a/src/DSi_SD.cpp
+++ b/src/DSi_SD.cpp
@@ -447,6 +447,7 @@ u16 DSi_SDHost::Read(u32 addr)
     case 0x028: return SDOption;
 
     case 0x02C: return 0; // TODO
+    case 0x02E: return 0; // TODO
 
     case 0x034: return CardIRQCtl;
     case 0x036: return CardIRQStatus;


### PR DESCRIPTION
Someone asked me if melonDS worked with dsiwifi and I wasn't sure if it did, so I threw my test_app executable at it (https://github.com/shinyquagsire23/dsiwifi/tree/main/test_app) and it failed fairly early.

Main issues I found and fixed:
 - I looped on CMD5 (IO_SEND_OP_COND) until it told me the card was ready. It's supposed to return card voltages but for melonDS I just set the high bit and left it at that.
 - I needed a response for CMD3 and CMD7
 - The MBOX FIFOs can work bytewise for BMI commands, and will only pop values off once written. I've been meaning to move dsiwifi away from this but I had trouble getting CMD53 to work early on.

Issues I found and couldn't fix:
 - Enabling CardIRQs seems to get stuck ~somewhere, but my prints aren't working even at the start of the handler, not sure what to make of it.
 - The second `wifi_ndma_wait()` in `wifi_card_write_func1_block` also hangs for some reason. I have a define to disable NDMA (SDIO_NO_BLOCKRW) that seems to fix this, and it at least gets a WMI_REG_DOMAIN_EVENT response fine.

I'll go ahead and make an issue for the other points, though.