### PR TITLE
InputConfigDialog: more DRY

### DIFF
--- a/src/frontend/qt_sdl/InputConfig/InputConfigDialog.cpp
+++ b/src/frontend/qt_sdl/InputConfig/InputConfigDialog.cpp
@@ -201,19 +201,19 @@ void InputConfigDialog::populatePage(QWidget* page, int num, const char** labels
 
 void InputConfigDialog::on_InputConfigDialog_accepted()
 {
-    for (int i = 0; i < 12; i++)
+    for (int i = 0; i < keypad_num; i++)
     {
         Config::KeyMapping[dskeyorder[i]] = keypadKeyMap[i];
         Config::JoyMapping[dskeyorder[i]] = keypadJoyMap[i];
     }
 
-    for (int i = 0; i < 2; i++)
+    for (int i = 0; i < hk_addons_num; i++)
     {
         Config::HKKeyMapping[hk_addons[i]] = addonsKeyMap[i];
         Config::HKJoyMapping[hk_addons[i]] = addonsJoyMap[i];
     }
 
-    for (int i = 0; i < 9; i++)
+    for (int i = 0; i < hk_general_num; i++)
     {
         Config::HKKeyMapping[hk_general[i]] = hkGeneralKeyMap[i];
         Config::HKJoyMapping[hk_general[i]] = hkGeneralJoyMap[i];


### PR DESCRIPTION
Tiny patch, catches a spot missed by f5f18f1.

(I noticed because I have a branch that adds an addon hotkey and incrementing `hk_addons_num` wasn't working.)