### PR TITLE
allow for not discarding bios/rom/firmware on reset

### DIFF
--- a/src/NDS.h
+++ b/src/NDS.h
@@ -215,7 +215,7 @@ extern u8* ARM7WRAM;
 
 bool Init();
 void DeInit();
-void Reset();
+void Reset(bool discord = true);
 void Stop();
 
 bool DoSavestate(Savestate* file);

--- a/src/NDSCart.cpp
+++ b/src/NDSCart.cpp
@@ -1409,18 +1409,21 @@ void DeInit()
     if (Cart) delete Cart;
 }
 
-void Reset()
+void Reset(bool discard)
 {
-    CartInserted = false;
-    if (CartROM) delete[] CartROM;
-    CartROM = nullptr;
-    CartROMSize = 0;
-    CartID = 0;
-    CartIsHomebrew = false;
-    CartIsDSi = false;
+    if (discard)
+    {
+        CartInserted = false;
+        if (CartROM) delete[] CartROM;
+        CartROM = nullptr;
+        CartROMSize = 0;
+        CartID = 0;
+        CartIsHomebrew = false;
+        CartIsDSi = false;
 
-    if (Cart) delete Cart;
-    Cart = nullptr;
+        if (Cart) delete Cart;
+        Cart = nullptr;
+    }
 
     ResetCart();
 }

--- a/src/NDSCart.h
+++ b/src/NDSCart.h
@@ -199,7 +199,7 @@ extern NDSBanner Banner;
 
 bool Init();
 void DeInit();
-void Reset();
+void Reset(bool discard = true);
 
 void DoSavestate(Savestate* file);
 

--- a/src/SPI.h
+++ b/src/SPI.h
@@ -54,7 +54,7 @@ extern u16 Cnt;
 
 bool Init();
 void DeInit();
-void Reset();
+void Reset(bool discard = true);
 void DoSavestate(Savestate* file);
 
 void WriteCnt(u16 val);


### PR DESCRIPTION
This is mainly for BizHawk (and potentially other frontends which don't want to clear out these files on reset). Clearing out these files became problematic for BizHawk since that ended up blowing up states to above 64 MB, due to all that memory getting marked as dirty from the deallocation/reloading of these files.