### PR TITLE
Treat SDL_INIT_JOYSTICK fail as non-critical

### DIFF
--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -2797,7 +2797,11 @@ int main(int argc, char** argv)
     {
         printf("SDL couldn't init rumble\n");
     }
-    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK) < 0)
+    if (SDL_Init(SDL_INIT_JOYSTICK) < 0)
+    {
+        printf("SDL couldn't init joystick\n");
+    }
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO) < 0)
     {
         QMessageBox::critical(NULL, "melonDS", "SDL shat itself :(");
         return 1;


### PR DESCRIPTION
Treating the fail of SDL_INIT_JOYSTICK as non-critical, because on some systems that SDL feature can for some reason fail. This leads to the emulator closing with a critical error, even though it would work perfectly fine with just a keyboard.