### PR TITLE
Swap screens hotkey functionality when displaying one screen

### DIFF
--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -2586,6 +2586,22 @@ void MainWindow::onChangeScreenSwap(bool checked)
 {
     Config::ScreenSwap = checked?1:0;
 
+    // Swap between top and bottom screen when displaying one screen. 
+    if (Config::ScreenSizing == 4)
+    {
+        // Bottom Screen.
+        Config::ScreenSizing = 5;
+        actScreenSizing[4]->setChecked(false);
+        actScreenSizing[Config::ScreenSizing]->setChecked(true);
+    }
+    else if (Config::ScreenSizing == 5)
+    {
+        // Top Screen.
+        Config::ScreenSizing = 4;
+        actScreenSizing[5]->setChecked(false);
+        actScreenSizing[Config::ScreenSizing]->setChecked(true);
+    }
+    
     emit screenLayoutChange();
 }
 


### PR DESCRIPTION
Quite a few games during gameplay only require a quick glance at the secondary screen for information or navigating menus. When fullscreen it would be nice to have the main gameplay display take up the entire display of the hardware running the emulator while still retaining access to the secondary DS display via the Swap screens hotkey. 