### PR TITLE
Add support for changing the DS and DSi battery level

### DIFF
--- a/src/ARMJIT.cpp
+++ b/src/ARMJIT.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2022 melonDS team, RSDuck
+    Copyright 2016-2022 melonDS team
 
     This file is part of melonDS.
 

--- a/src/ARMJIT.h
+++ b/src/ARMJIT.h
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2022 melonDS team, RSDuck
+    Copyright 2016-2022 melonDS team
 
     This file is part of melonDS.
 

--- a/src/ARMJIT_Memory.cpp
+++ b/src/ARMJIT_Memory.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2022 melonDS team, RSDuck
+    Copyright 2016-2022 melonDS team
 
     This file is part of melonDS.
 
@@ -55,7 +55,7 @@
     and map the memory regions as they're structured on the DS
     in it.
 
-    On most systems you have a single piece of main ram, 
+    On most systems you have a single piece of main ram,
     maybe some video ram and faster cache RAM and that's about it.
     Here we have not only a lot more different memory regions,
     but also two address spaces. Not only that but they all have
@@ -119,7 +119,7 @@ void HandleFault(u64 pc, u64 lr, u64 fp, u64 faultAddr, u32 desc);
 
 extern "C"
 {
-    
+
 void ARM_RestoreContext(u64* registers) __attribute__((noreturn));
 
 extern char __start__;
@@ -146,7 +146,7 @@ void __libnx_exception_handler(ThreadExceptionDump* ctx)
     {
         integerRegisters[32] = (u64)desc.FaultPC;
 
-        ARM_RestoreContext(integerRegisters);	
+        ARM_RestoreContext(integerRegisters);
     }
 
     HandleFault(ctx->pc.x, ctx->lr.x, ctx->fp.x, ctx->far.x, ctx->error_desc);
@@ -311,7 +311,7 @@ bool MapIntoRange(u32 addr, u32 num, u32 offset, u32 size)
 {
     u8* dst = (u8*)(num == 0 ? FastMem9Start : FastMem7Start) + addr;
 #ifdef __SWITCH__
-    Result r = (svcMapProcessMemory(dst, envGetOwnProcessHandle(), 
+    Result r = (svcMapProcessMemory(dst, envGetOwnProcessHandle(),
         (u64)(MemoryBaseCodeMem + offset), size));
     return R_SUCCEEDED(r);
 #elif defined(_WIN32)
@@ -452,7 +452,7 @@ void SetCodeProtection(int region, u32 offset, bool protect)
 
         u32 effectiveAddr = mapping.Addr + (offset - mapping.LocalOffset);
         if (mapping.Num == 0
-            && region != memregion_DTCM 
+            && region != memregion_DTCM
             && (effectiveAddr & NDS::ARM9->DTCMMask) == NDS::ARM9->DTCMBase)
             continue;
 
@@ -621,7 +621,7 @@ bool MapAtAddress(u32 addr)
 
     // this overcomplicated piece of code basically just finds whole pieces of code memory
     // which can be mapped/protected
-    u32 offset = 0;	
+    u32 offset = 0;
     bool skipDTCM = num == 0 && region != memregion_DTCM;
     while (offset < mirrorSize)
     {
@@ -700,10 +700,10 @@ void Init()
     virtmemLock();
     MemoryBaseCodeMem = (u8*)virtmemFindCodeMemory(MemoryTotalSize, 0x1000);
 
-    bool succeded = R_SUCCEEDED(svcMapProcessCodeMemory(envGetOwnProcessHandle(), (u64)MemoryBaseCodeMem, 
+    bool succeded = R_SUCCEEDED(svcMapProcessCodeMemory(envGetOwnProcessHandle(), (u64)MemoryBaseCodeMem,
         (u64)MemoryBase, MemoryTotalSize));
     assert(succeded);
-    succeded = R_SUCCEEDED(svcSetProcessMemoryPermission(envGetOwnProcessHandle(), (u64)MemoryBaseCodeMem, 
+    succeded = R_SUCCEEDED(svcSetProcessMemoryPermission(envGetOwnProcessHandle(), (u64)MemoryBaseCodeMem,
         MemoryTotalSize, Perm_Rw));
     assert(succeded);
 
@@ -740,7 +740,7 @@ void Init()
     u8* basePtr = MemoryBase;
 #else
     // this used to be allocated with three different mmaps
-    // The idea was to give the OS more freedom where to position the buffers, 
+    // The idea was to give the OS more freedom where to position the buffers,
     // but something was bad about this so instead we take this vmem eating monster
     // which seems to work better.
     MemoryBase = (u8*)mmap(NULL, AddrSpaceSize*4, PROT_NONE, MAP_ANON | MAP_PRIVATE, -1, 0);
@@ -855,7 +855,7 @@ bool IsFastmemCompatible(int region)
         TODO: with some hacks, the smaller shared WRAM regions
         could be mapped in some occaisons as well
     */
-    if (region == memregion_DTCM 
+    if (region == memregion_DTCM
         || region == memregion_SharedWRAM
         || region == memregion_NewSharedWRAM_B
         || region == memregion_NewSharedWRAM_C)
@@ -1071,7 +1071,7 @@ int ClassifyAddress9(u32 addr)
     {
         return memregion_DTCM;
     }
-    else 
+    else
     {
         if (NDS::ConsoleType == 1 && addr >= 0xFFFF0000 && !(DSi::SCFG_BIOS & (1<<1)))
         {
@@ -1219,8 +1219,8 @@ void* GetFuncForAddr(ARM* cpu, u32 addr, bool store, int size)
             {
                 switch (size | store)
                 {
-                case 8: return (void*)GPU3D::Read8;		
-                case 9: return (void*)GPU3D::Write8;		
+                case 8: return (void*)GPU3D::Read8;
+                case 9: return (void*)GPU3D::Write8;
                 case 16: return (void*)GPU3D::Read16;
                 case 17: return (void*)GPU3D::Write16;
                 case 32: return (void*)GPU3D::Read32;
@@ -1256,7 +1256,7 @@ void* GetFuncForAddr(ARM* cpu, u32 addr, bool store, int size)
         case 0x06000000:
             switch (size | store)
             {
-            case 8: return (void*)VRAMRead<u8>;		
+            case 8: return (void*)VRAMRead<u8>;
             case 9: return NULL;
             case 16: return (void*)VRAMRead<u16>;
             case 17: return (void*)VRAMWrite<u16>;
@@ -1275,8 +1275,8 @@ void* GetFuncForAddr(ARM* cpu, u32 addr, bool store, int size)
             {
                 switch (size | store)
                 {
-                case 8: return (void*)SPU::Read8;		
-                case 9: return (void*)SPU::Write8;		
+                case 8: return (void*)SPU::Read8;
+                case 9: return (void*)SPU::Write8;
                 case 16: return (void*)SPU::Read16;
                 case 17: return (void*)SPU::Write16;
                 case 32: return (void*)SPU::Read32;
@@ -1289,7 +1289,7 @@ void* GetFuncForAddr(ARM* cpu, u32 addr, bool store, int size)
                 switch (size | store)
                 {
                 case 8: return (void*)NDS::ARM7IORead8;
-                case 9: return (void*)NDS::ARM7IOWrite8;		
+                case 9: return (void*)NDS::ARM7IOWrite8;
                 case 16: return (void*)NDS::ARM7IORead16;
                 case 17: return (void*)NDS::ARM7IOWrite16;
                 case 32: return (void*)NDS::ARM7IORead32;
@@ -1301,7 +1301,7 @@ void* GetFuncForAddr(ARM* cpu, u32 addr, bool store, int size)
                 switch (size | store)
                 {
                 case 8: return (void*)DSi::ARM7IORead8;
-                case 9: return (void*)DSi::ARM7IOWrite8;		
+                case 9: return (void*)DSi::ARM7IOWrite8;
                 case 16: return (void*)DSi::ARM7IORead16;
                 case 17: return (void*)DSi::ARM7IOWrite16;
                 case 32: return (void*)DSi::ARM7IORead32;

--- a/src/ARMJIT_Memory.h
+++ b/src/ARMJIT_Memory.h
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2022 melonDS team, RSDuck
+    Copyright 2016-2022 melonDS team
 
     This file is part of melonDS.
 

--- a/src/ARMJIT_x64/ARMJIT_ALU.cpp
+++ b/src/ARMJIT_x64/ARMJIT_ALU.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2022 melonDS team, RSDuck
+    Copyright 2016-2022 melonDS team
 
     This file is part of melonDS.
 
@@ -364,7 +364,7 @@ void Compiler::A_Comp_Mul_Long()
         {
             BSR(32, RSCRATCH, R(RSCRATCH3));
         }
-        
+
         SHR(32, R(RSCRATCH), Imm8(3));
         SetJumpTarget(zeroBSR); // fortunately that's even right
         Comp_AddCycles_CI(RSCRATCH, 2);
@@ -617,7 +617,7 @@ void Compiler::T_Comp_AddSub_()
     int op = (CurInstr.Instr >> 9) & 0x3;
 
     OpArg rn = op >= 2 ? Imm32((CurInstr.Instr >> 6) & 0x7) : MapReg(CurInstr.T_Reg(6));
-    
+
     Comp_AddCycles_C();
 
     // special case for thumb mov being alias to add rd, rn, #0

--- a/src/ARMJIT_x64/ARMJIT_Branch.cpp
+++ b/src/ARMJIT_x64/ARMJIT_Branch.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2022 melonDS team, RSDuck
+    Copyright 2016-2022 melonDS team
 
     This file is part of melonDS.
 
@@ -30,7 +30,7 @@ int squeezePointer(T* ptr)
     assert((T*)((u64)truncated) == ptr);
     return truncated;
 }
-    
+
 void Compiler::Comp_JumpTo(u32 addr, bool forceNonConstantCycles)
 {
     // we can simplify constant branches by a lot

--- a/src/ARMJIT_x64/ARMJIT_Compiler.cpp
+++ b/src/ARMJIT_x64/ARMJIT_Compiler.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2022 melonDS team, RSDuck
+    Copyright 2016-2022 melonDS team
 
     This file is part of melonDS.
 

--- a/src/ARMJIT_x64/ARMJIT_Compiler.h
+++ b/src/ARMJIT_x64/ARMJIT_Compiler.h
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2022 melonDS team, RSDuck
+    Copyright 2016-2022 melonDS team
 
     This file is part of melonDS.
 
@@ -121,7 +121,7 @@ public:
     void A_Comp_Mul_Long();
 
     void A_Comp_CLZ();
-    
+
     void A_Comp_MemWB();
     void A_Comp_MemHalf();
     void A_Comp_LDM_STM();
@@ -170,7 +170,7 @@ public:
     s32 Comp_MemAccessBlock(int rn, BitSet16 regs, bool store, bool preinc, bool decrement, bool usermode, bool skipLoadingRn);
     bool Comp_MemLoadLiteral(int size, bool signExtend, int rd, u32 addr);
 
-    void Comp_ArithTriOp(void (Compiler::*op)(int, const Gen::OpArg&, const Gen::OpArg&), 
+    void Comp_ArithTriOp(void (Compiler::*op)(int, const Gen::OpArg&, const Gen::OpArg&),
         Gen::OpArg rd, Gen::OpArg rn, Gen::OpArg op2, bool carryUsed, int opFlags);
     void Comp_ArithTriOpReverse(void (Compiler::*op)(int, const Gen::OpArg&, const Gen::OpArg&),
         Gen::OpArg rd, Gen::OpArg rn, Gen::OpArg op2, bool carryUsed, int opFlags);

--- a/src/ARMJIT_x64/ARMJIT_Linkage.S
+++ b/src/ARMJIT_x64/ARMJIT_Linkage.S
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2022 melonDS team, RSDuck
+    Copyright 2016-2022 melonDS team
 
     This file is part of melonDS.
 

--- a/src/ARMJIT_x64/ARMJIT_LoadStore.cpp
+++ b/src/ARMJIT_x64/ARMJIT_LoadStore.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2022 melonDS team, RSDuck
+    Copyright 2016-2022 melonDS team
 
     This file is part of melonDS.
 

--- a/src/ARM_InstrInfo.cpp
+++ b/src/ARM_InstrInfo.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2022 melonDS team, RSDuck
+    Copyright 2016-2022 melonDS team
 
     This file is part of melonDS.
 

--- a/src/ARM_InstrInfo.h
+++ b/src/ARM_InstrInfo.h
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2022 melonDS team, RSDuck
+    Copyright 2016-2022 melonDS team
 
     This file is part of melonDS.
 
@@ -222,7 +222,7 @@ enum
     tk_POP,
     tk_LDMIA,
     tk_STMIA,
-    
+
     tk_BCOND,
     tk_BX,
     tk_BLX_REG,

--- a/src/DSi_I2C.cpp
+++ b/src/DSi_I2C.cpp
@@ -22,6 +22,7 @@
 #include "DSi_I2C.h"
 #include "DSi_Camera.h"
 #include "ARM.h"
+#include "SPI.h"
 
 
 namespace DSi_BPTWL
@@ -81,6 +82,19 @@ void DoSavestate(Savestate* file)
 }
 
 u8 GetBootFlag() { return Registers[0x70]; }
+
+bool GetBatteryCharging() { return Registers[0x20] >> 7; }
+void SetBatteryCharging(bool charging)
+{
+    Registers[0x20] = (((charging ? 0x8 : 0x0) << 4) | (Registers[0x20] & 0x0F));
+}
+
+u8 GetBatteryLevel() { return Registers[0x20] & 0xF; }
+void SetBatteryLevel(u8 batteryLevel)
+{
+    Registers[0x20] = ((Registers[0x20] & 0xF0) | (batteryLevel & 0x0F));
+    SPI_Powerman::SetBatteryLevelOkay(batteryLevel > batteryLevel_Low ? true : false);
+}
 
 void Start()
 {

--- a/src/DSi_I2C.h
+++ b/src/DSi_I2C.h
@@ -19,11 +19,28 @@
 #ifndef DSI_I2C_H
 #define DSI_I2C_H
 
+#include "types.h"
+
 namespace DSi_BPTWL
 {
 
 u8 GetBootFlag();
 
+bool GetBatteryCharging();
+void SetBatteryCharging(bool charging);
+
+enum
+{
+    batteryLevel_Critical = 0x0,
+    batteryLevel_AlmostEmpty = 0x1,
+    batteryLevel_Low = 0x3,
+    batteryLevel_Half = 0x7,
+    batteryLevel_ThreeQuarters = 0xB,
+    batteryLevel_Full = 0xF
+};
+
+u8 GetBatteryLevel();
+void SetBatteryLevel(u8 batteryLevel);
 }
 
 namespace DSi_I2C

--- a/src/GBACart.cpp
+++ b/src/GBACart.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2022 melonDS team, Raphaël Zumer
+    Copyright 2016-2022 melonDS team
 
     This file is part of melonDS.
 

--- a/src/GBACart.h
+++ b/src/GBACart.h
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2022 melonDS team, Raphaël Zumer
+    Copyright 2016-2022 melonDS team
 
     This file is part of melonDS.
 

--- a/src/SPI.cpp
+++ b/src/SPI.cpp
@@ -618,7 +618,7 @@ void Reset()
     Registers[4] = 0x40;
 
     RegMasks[0] = 0x7F;
-    RegMasks[1] = 0x01;
+    RegMasks[1] = 0x00;
     RegMasks[2] = 0x01;
     RegMasks[3] = 0x03;
     RegMasks[4] = 0x0F;
@@ -663,6 +663,7 @@ void Write(u8 val, u32 hold)
 
     if (DataPos == 1)
     {
+        // TODO: DSi-specific registers in DSi mode
         u32 regid = Index & 0x07;
 
         if (Index & 0x80)

--- a/src/SPI.cpp
+++ b/src/SPI.cpp
@@ -624,6 +624,9 @@ void Reset()
     RegMasks[4] = 0x0F;
 }
 
+bool GetBatteryLevelOkay() { return !Registers[1]; }
+void SetBatteryLevelOkay(bool okay) { Registers[1] = okay ? 0x00 : 0x01; }
+
 void DoSavestate(Savestate* file)
 {
     file->Section("SPPW");

--- a/src/SPI.h
+++ b/src/SPI.h
@@ -37,6 +37,14 @@ u8* GetWifiMAC();
 
 }
 
+namespace SPI_Powerman
+{
+
+bool GetBatteryLevelOkay();
+void SetBatteryLevelOkay(bool okay);
+
+}
+
 namespace SPI_TSC
 {
 

--- a/src/frontend/qt_sdl/ArchiveUtil.cpp
+++ b/src/frontend/qt_sdl/ArchiveUtil.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2022 melonDS team, WaluigiWare64
+    Copyright 2016-2022 melonDS team
 
     This file is part of melonDS.
 

--- a/src/frontend/qt_sdl/ArchiveUtil.h
+++ b/src/frontend/qt_sdl/ArchiveUtil.h
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2022 melonDS team, WaluigiWare64
+    Copyright 2016-2022 melonDS team
 
     This file is part of melonDS.
 

--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -6,6 +6,8 @@ SET(SOURCES_QT_SDL
     CheatsDialog.cpp
 	Config.cpp
     EmuSettingsDialog.cpp
+    PowerManagement/PowerManagementDialog.cpp
+    PowerManagement/resources/battery.qrc
     InputConfig/InputConfigDialog.cpp
     InputConfig/MapButton.h
     InputConfig/resources/ds.qrc

--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -135,6 +135,10 @@ int MouseHideSeconds;
 
 bool PauseLostFocus;
 
+bool DSBatteryLevelOkay;
+int DSiBatteryLevel;
+bool DSiBatteryCharging;
+
 
 const char* kConfigFile = "melonDS.ini";
 
@@ -304,6 +308,10 @@ ConfigEntry ConfigFile[] =
     {"MouseHide",        1, &MouseHide,        false},
     {"MouseHideSeconds", 0, &MouseHideSeconds, 5},
     {"PauseLostFocus",   1, &PauseLostFocus,   false},
+
+    {"DSBatteryLevelOkay",   1, &DSBatteryLevelOkay, true},
+    {"DSiBatteryLevel",    0, &DSiBatteryLevel, 0xF},
+    {"DSiBatteryCharging", 1, &DSiBatteryCharging, true},
 
     {"", -1, nullptr, 0}
 };

--- a/src/frontend/qt_sdl/Config.h
+++ b/src/frontend/qt_sdl/Config.h
@@ -158,6 +158,10 @@ extern bool MouseHide;
 extern int MouseHideSeconds;
 extern bool PauseLostFocus;
 
+extern bool DSBatteryLevelOkay;
+extern int DSiBatteryLevel;
+extern bool DSiBatteryCharging;
+
 
 void Load();
 void Save();

--- a/src/frontend/qt_sdl/FirmwareSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/FirmwareSettingsDialog.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2020 Arisotura
+    Copyright 2016-2022 melonDS team
 
     This file is part of melonDS.
 

--- a/src/frontend/qt_sdl/FirmwareSettingsDialog.h
+++ b/src/frontend/qt_sdl/FirmwareSettingsDialog.h
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2020 Arisotura
+    Copyright 2016-2022 melonDS team
 
     This file is part of melonDS.
 

--- a/src/frontend/qt_sdl/InterfaceSettingsDialog.cpp
+++ b/src/frontend/qt_sdl/InterfaceSettingsDialog.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2022 melonDS team, WaluigiWare64
+    Copyright 2016-2022 melonDS team
 
     This file is part of melonDS.
 

--- a/src/frontend/qt_sdl/InterfaceSettingsDialog.h
+++ b/src/frontend/qt_sdl/InterfaceSettingsDialog.h
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2022 melonDS team, WaluigiWare64
+    Copyright 2016-2022 melonDS team
 
     This file is part of melonDS.
 

--- a/src/frontend/qt_sdl/PowerManagement/PowerManagementDialog.cpp
+++ b/src/frontend/qt_sdl/PowerManagement/PowerManagementDialog.cpp
@@ -22,6 +22,7 @@
 #include "SPI.h"
 #include "DSi_I2C.h"
 #include "NDS.h"
+#include "Config.h"
 
 #include "types.h"
 
@@ -40,8 +41,8 @@ PowerManagementDialog::PowerManagementDialog(QWidget* parent) : QDialog(parent),
     {
         ui->grpDSBattery->setEnabled(false);
 
-        oldDSiBatteryCharging = DSi_BPTWL::GetBatteryCharging();
         oldDSiBatteryLevel = DSi_BPTWL::GetBatteryLevel();
+        oldDSiBatteryCharging = DSi_BPTWL::GetBatteryCharging();
     }
     else
     {
@@ -74,12 +75,24 @@ PowerManagementDialog::~PowerManagementDialog()
 
 void PowerManagementDialog::done(int r)
 {
-    if (r != QDialog::Accepted)
+    if (r == QDialog::Accepted)
     {
         if (NDS::ConsoleType == 1)
         {
-            DSi_BPTWL::SetBatteryCharging(oldDSiBatteryCharging);
+            Config::DSiBatteryLevel = DSi_BPTWL::GetBatteryLevel();
+            Config::DSiBatteryCharging = DSi_BPTWL::GetBatteryCharging();
+        }
+        else
+        {
+            Config::DSBatteryLevelOkay = SPI_Powerman::GetBatteryLevelOkay();
+        }
+    }
+    else
+    {
+        if (NDS::ConsoleType == 1)
+        {
             DSi_BPTWL::SetBatteryLevel(oldDSiBatteryLevel);
+            DSi_BPTWL::SetBatteryCharging(oldDSiBatteryCharging);
         }
         else
         {

--- a/src/frontend/qt_sdl/PowerManagement/PowerManagementDialog.cpp
+++ b/src/frontend/qt_sdl/PowerManagement/PowerManagementDialog.cpp
@@ -1,0 +1,106 @@
+/*
+    Copyright 2016-2021 Rayyan Ansari
+
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#include "PowerManagementDialog.h"
+#include "ui_PowerManagementDialog.h"
+
+#include "SPI.h"
+#include "DSi_I2C.h"
+#include "NDS.h"
+
+#include "types.h"
+
+#include <QtDebug>
+
+PowerManagementDialog* PowerManagementDialog::currentDlg = nullptr;
+
+PowerManagementDialog::PowerManagementDialog(QWidget* parent) : QDialog(parent), ui(new Ui::PowerManagementDialog)
+{
+    ui->setupUi(this);
+    setAttribute(Qt::WA_DeleteOnClose);
+
+    if (NDS::ConsoleType)
+        ui->grpDSBattery->setEnabled(false);
+    else
+        ui->grpDSiBattery->setEnabled(false);
+
+    updateDSBatteryLevelControls();
+
+    ui->cbDSiBatteryCharging->setChecked(DSi_BPTWL::GetBatteryCharging());
+    int dsiBatterySliderPos;
+    switch (DSi_BPTWL::GetBatteryLevel())
+    {
+        case DSi_BPTWL::batteryLevel_AlmostEmpty:   dsiBatterySliderPos = 0; break;
+        case DSi_BPTWL::batteryLevel_Low:           dsiBatterySliderPos = 1; break;
+        case DSi_BPTWL::batteryLevel_Half:          dsiBatterySliderPos = 2; break;
+        case DSi_BPTWL::batteryLevel_ThreeQuarters: dsiBatterySliderPos = 3; break;
+        case DSi_BPTWL::batteryLevel_Full:          dsiBatterySliderPos = 4; break;
+    }
+    ui->sliderDSiBatteryLevel->setValue(dsiBatterySliderPos);
+}
+
+PowerManagementDialog::~PowerManagementDialog()
+{
+    delete ui;
+}
+
+void PowerManagementDialog::done(int r)
+{
+    QDialog::done(r);
+
+    closeDlg();
+}
+
+void PowerManagementDialog::on_rbDSBatteryLow_clicked()
+{
+    SPI_Powerman::SetBatteryLevelOkay(false);
+}
+
+void PowerManagementDialog::on_rbDSBatteryOkay_clicked()
+{
+    SPI_Powerman::SetBatteryLevelOkay(true);
+}
+
+void PowerManagementDialog::updateDSBatteryLevelControls()
+{
+    if (SPI_Powerman::GetBatteryLevelOkay())
+        ui->rbDSBatteryOkay->setChecked(true);
+    else
+        ui->rbDSBatteryLow->setChecked(true);
+}
+
+void PowerManagementDialog::on_cbDSiBatteryCharging_toggled()
+{
+    DSi_BPTWL::SetBatteryCharging(ui->cbDSiBatteryCharging->isChecked());
+}
+
+void PowerManagementDialog::on_sliderDSiBatteryLevel_valueChanged(int value)
+{
+    u8 newBatteryLevel;
+    switch (value)
+    {
+        case 0: newBatteryLevel = DSi_BPTWL::batteryLevel_AlmostEmpty; break;
+        case 1: newBatteryLevel = DSi_BPTWL::batteryLevel_Low; break;
+        case 2: newBatteryLevel = DSi_BPTWL::batteryLevel_Half; break;
+        case 3: newBatteryLevel = DSi_BPTWL::batteryLevel_ThreeQuarters; break;
+        case 4: newBatteryLevel = DSi_BPTWL::batteryLevel_Full; break;
+    }
+    DSi_BPTWL::SetBatteryLevel(newBatteryLevel);
+    updateDSBatteryLevelControls();
+}
+

--- a/src/frontend/qt_sdl/PowerManagement/PowerManagementDialog.cpp
+++ b/src/frontend/qt_sdl/PowerManagement/PowerManagementDialog.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2021 Rayyan Ansari
+    Copyright 2016-2022 melonDS team
 
     This file is part of melonDS.
 

--- a/src/frontend/qt_sdl/PowerManagement/PowerManagementDialog.h
+++ b/src/frontend/qt_sdl/PowerManagement/PowerManagementDialog.h
@@ -1,5 +1,6 @@
 /*
-    Copyright 2016-2021 Rayyan Ansari
+    Copyright 2016-2022 melonDS team
+
     This file is part of melonDS.
 
     melonDS is free software: you can redistribute it and/or modify it under

--- a/src/frontend/qt_sdl/PowerManagement/PowerManagementDialog.h
+++ b/src/frontend/qt_sdl/PowerManagement/PowerManagementDialog.h
@@ -1,0 +1,69 @@
+/*
+    Copyright 2016-2021 Rayyan Ansari
+    This file is part of melonDS.
+
+    melonDS is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option)
+    any later version.
+
+    melonDS is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with melonDS. If not, see http://www.gnu.org/licenses/.
+*/
+
+#ifndef POWERMANAGEMENTDIALOG_H
+#define POWERMANAGEMENTDIALOG_H
+
+#include <QDialog>
+#include <QAbstractButton>
+
+namespace Ui { class PowerManagementDialog; }
+class PowerManagementDialog;
+
+class PowerManagementDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit PowerManagementDialog(QWidget* parent);
+    ~PowerManagementDialog();
+
+    static PowerManagementDialog* currentDlg;
+    static PowerManagementDialog* openDlg(QWidget* parent)
+    {
+        if (currentDlg)
+        {
+            currentDlg->activateWindow();
+            return currentDlg;
+        }
+
+        currentDlg = new PowerManagementDialog(parent);
+        currentDlg->open();
+        return currentDlg;
+    }
+    static void closeDlg()
+    {
+        currentDlg = nullptr;
+    }
+
+private slots:
+    void done(int r);
+
+    void on_rbDSBatteryLow_clicked();
+    void on_rbDSBatteryOkay_clicked();
+
+    void on_cbDSiBatteryCharging_toggled();
+    void on_sliderDSiBatteryLevel_valueChanged(int value);
+
+private:
+    Ui::PowerManagementDialog* ui;
+
+    void updateDSBatteryLevelControls();
+};
+
+#endif // POWERMANAGEMENTDIALOG_H
+

--- a/src/frontend/qt_sdl/PowerManagement/PowerManagementDialog.h
+++ b/src/frontend/qt_sdl/PowerManagement/PowerManagementDialog.h
@@ -67,8 +67,8 @@ private:
 
     bool inited;
     bool oldDSBatteryLevel;
-    bool oldDSiBatteryCharging;
     u8 oldDSiBatteryLevel;
+    bool oldDSiBatteryCharging;
 
     void updateDSBatteryLevelControls();
 };

--- a/src/frontend/qt_sdl/PowerManagement/PowerManagementDialog.h
+++ b/src/frontend/qt_sdl/PowerManagement/PowerManagementDialog.h
@@ -22,6 +22,8 @@
 #include <QDialog>
 #include <QAbstractButton>
 
+#include "types.h"
+
 namespace Ui { class PowerManagementDialog; }
 class PowerManagementDialog;
 
@@ -62,6 +64,11 @@ private slots:
 
 private:
     Ui::PowerManagementDialog* ui;
+
+    bool inited;
+    bool oldDSBatteryLevel;
+    bool oldDSiBatteryCharging;
+    u8 oldDSiBatteryLevel;
 
     void updateDSBatteryLevelControls();
 };

--- a/src/frontend/qt_sdl/PowerManagement/PowerManagementDialog.ui
+++ b/src/frontend/qt_sdl/PowerManagement/PowerManagementDialog.ui
@@ -1,0 +1,258 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PowerManagementDialog</class>
+ <widget class="QDialog" name="PowerManagementDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>562</width>
+    <height>279</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Power management - melonDS</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="grpDSBattery">
+     <property name="title">
+      <string>DS Battery</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="1" column="1">
+       <widget class="QRadioButton" name="rbDSBatteryLow">
+        <property name="text">
+         <string>Low</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" rowspan="2">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Battery Level</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QRadioButton" name="rbDSBatteryOkay">
+        <property name="text">
+         <string>Okay</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="grpDSiBattery">
+     <property name="title">
+      <string>DSi Battery</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_6">
+      <item row="1" column="2">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Almost Empty</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Preferred</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="0" colspan="5">
+       <widget class="QCheckBox" name="cbDSiBatteryCharging">
+        <property name="text">
+         <string>Charging</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="8">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Full</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_1">
+        <property name="text">
+         <string>Battery Level</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="3">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="pixmap">
+         <pixmap resource="resources/battery.qrc">:/dsibattery/dsi_batteryalmostempty.svg</pixmap>
+        </property>
+        <property name="scaledContents">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="4">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="pixmap">
+         <pixmap resource="resources/battery.qrc">:/dsibattery/dsi_batterylow.svg</pixmap>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="5">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="pixmap">
+         <pixmap resource="resources/battery.qrc">:/dsibattery/dsi_battery2.svg</pixmap>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="6">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="pixmap">
+         <pixmap resource="resources/battery.qrc">:/dsibattery/dsi_battery3.svg</pixmap>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="7">
+       <widget class="QLabel" name="label_8">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="pixmap">
+         <pixmap resource="resources/battery.qrc">:/dsibattery/dsi_batteryfull.svg</pixmap>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3" colspan="5">
+       <widget class="QSlider" name="sliderDSiBatteryLevel">
+        <property name="maximum">
+         <number>4</number>
+        </property>
+        <property name="pageStep">
+         <number>1</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="tickPosition">
+         <enum>QSlider::TicksBothSides</enum>
+        </property>
+        <property name="tickInterval">
+         <number>1</number>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="3">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="resources/battery.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>PowerManagementDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>PowerManagementDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/frontend/qt_sdl/PowerManagement/PowerManagementDialog.ui
+++ b/src/frontend/qt_sdl/PowerManagement/PowerManagementDialog.ui
@@ -20,6 +20,9 @@
    <string>Power management - melonDS</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetFixedSize</enum>
+   </property>
    <item row="0" column="0">
     <widget class="QGroupBox" name="grpDSBattery">
      <property name="title">

--- a/src/frontend/qt_sdl/PowerManagement/resources/battery.qrc
+++ b/src/frontend/qt_sdl/PowerManagement/resources/battery.qrc
@@ -1,0 +1,9 @@
+<RCC>
+  <qresource prefix="dsibattery">
+    <file>dsi_batteryalmostempty.svg</file>
+    <file>dsi_batterylow.svg</file>
+    <file>dsi_battery2.svg</file>
+    <file>dsi_battery3.svg</file>
+    <file>dsi_batteryfull.svg</file>
+  </qresource>
+</RCC>

--- a/src/frontend/qt_sdl/PowerManagement/resources/dsi_battery2.svg
+++ b/src/frontend/qt_sdl/PowerManagement/resources/dsi_battery2.svg
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="12.236976mm"
+   height="6.2838535mm"
+   viewBox="0 0 12.236976 6.283854"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="battery2.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ff8100"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="1"
+     inkscape:pagecheckerboard="false"
+     inkscape:document-units="mm"
+     showgrid="true"
+     height="200mm"
+     showborder="true"
+     inkscape:showpageshadow="false"
+     borderlayer="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="10.24"
+     inkscape:cx="2.7832031"
+     inkscape:cy="2.0507813"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11"
+       spacingx="0.26458333"
+       spacingy="0.26458333"
+       originx="-91.777345"
+       originy="-47.128916" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-91.777344,-47.12891)">
+    <rect
+       style="fill:#000000;fill-rule:evenodd;stroke-width:0.0211535"
+       id="rect153"
+       width="1.3229166"
+       height="2.9765623"
+       x="91.777344"
+       y="48.782555" />
+    <rect
+       style="fill:#000000;stroke-width:0.0162915"
+       id="rect177"
+       width="10.914062"
+       height="0.66145831"
+       x="93.100258"
+       y="47.12891" />
+    <rect
+       style="fill:#000000;stroke-width:0.0165364"
+       id="rect179"
+       width="0.66145831"
+       height="4.9609375"
+       x="93.100258"
+       y="47.790367" />
+    <rect
+       style="fill:#000000;stroke-width:0.0162915"
+       id="rect181"
+       width="10.914062"
+       height="0.66145873"
+       x="93.100258"
+       y="52.751305" />
+    <rect
+       style="fill:#000000;stroke-width:0.0165364"
+       id="rect183"
+       width="0.66145831"
+       height="4.9609375"
+       x="103.35286"
+       y="47.790367" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0162585"
+       id="rect318"
+       width="9.5911455"
+       height="0.49609375"
+       x="93.761719"
+       y="47.790367" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0158876"
+       id="rect408"
+       width="0.49609372"
+       height="3.96875"
+       x="93.761719"
+       y="48.286461" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.015706"
+       id="rect410"
+       width="9.5911455"
+       height="0.49609351"
+       x="93.761719"
+       y="52.255211" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0158876"
+       id="rect412"
+       width="0.4960939"
+       height="3.9687498"
+       x="102.85677"
+       y="48.286461" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0224686"
+       id="rect414"
+       width="0.66145849"
+       height="3.9687498"
+       x="95.911453"
+       y="48.286461" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0158876"
+       id="rect414-3"
+       width="0.66145885"
+       height="3.9687498"
+       x="98.226562"
+       y="48.286461" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0158876"
+       id="rect414-6"
+       width="0.66145819"
+       height="3.9687498"
+       x="100.54166"
+       y="48.286461" />
+    <rect
+       style="fill:#999999;stroke-width:0.0165364"
+       id="rect1736"
+       width="1.6536455"
+       height="3.9687498"
+       x="94.257812"
+       y="48.286461" />
+    <rect
+       style="fill:#999999;stroke-width:0.0165364"
+       id="rect1738"
+       width="1.6536458"
+       height="3.96875"
+       x="96.572914"
+       y="48.286461" />
+    <rect
+       style="fill:#00ccff;stroke-width:0.0165364"
+       id="rect1740"
+       width="1.6536458"
+       height="3.96875"
+       x="98.888016"
+       y="48.286461" />
+    <rect
+       style="fill:#00ccff;stroke-width:0.0165364"
+       id="rect1742"
+       width="1.6536458"
+       height="3.96875"
+       x="101.20312"
+       y="48.286461" />
+  </g>
+</svg>

--- a/src/frontend/qt_sdl/PowerManagement/resources/dsi_battery3.svg
+++ b/src/frontend/qt_sdl/PowerManagement/resources/dsi_battery3.svg
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="12.236976mm"
+   height="6.2838535mm"
+   viewBox="0 0 12.236976 6.283854"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="battery3.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ff8100"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="1"
+     inkscape:pagecheckerboard="false"
+     inkscape:document-units="mm"
+     showgrid="true"
+     height="200mm"
+     showborder="true"
+     inkscape:showpageshadow="false"
+     borderlayer="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="10.24"
+     inkscape:cx="2.7832031"
+     inkscape:cy="2.0507813"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11"
+       spacingx="0.26458333"
+       spacingy="0.26458333"
+       originx="-91.777345"
+       originy="-47.128916" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-91.777344,-47.12891)">
+    <rect
+       style="fill:#000000;fill-rule:evenodd;stroke-width:0.0211535"
+       id="rect153"
+       width="1.3229166"
+       height="2.9765623"
+       x="91.777344"
+       y="48.782555" />
+    <rect
+       style="fill:#000000;stroke-width:0.0162915"
+       id="rect177"
+       width="10.914062"
+       height="0.66145831"
+       x="93.100258"
+       y="47.12891" />
+    <rect
+       style="fill:#000000;stroke-width:0.0165364"
+       id="rect179"
+       width="0.66145831"
+       height="4.9609375"
+       x="93.100258"
+       y="47.790367" />
+    <rect
+       style="fill:#000000;stroke-width:0.0162915"
+       id="rect181"
+       width="10.914062"
+       height="0.66145873"
+       x="93.100258"
+       y="52.751305" />
+    <rect
+       style="fill:#000000;stroke-width:0.0165364"
+       id="rect183"
+       width="0.66145831"
+       height="4.9609375"
+       x="103.35286"
+       y="47.790367" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0162585"
+       id="rect318"
+       width="9.5911455"
+       height="0.49609375"
+       x="93.761719"
+       y="47.790367" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0158876"
+       id="rect408"
+       width="0.49609372"
+       height="3.96875"
+       x="93.761719"
+       y="48.286461" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.015706"
+       id="rect410"
+       width="9.5911455"
+       height="0.49609351"
+       x="93.761719"
+       y="52.255211" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0158876"
+       id="rect412"
+       width="0.4960939"
+       height="3.9687498"
+       x="102.85677"
+       y="48.286461" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0224686"
+       id="rect414"
+       width="0.66145849"
+       height="3.9687498"
+       x="95.911453"
+       y="48.286461" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0158876"
+       id="rect414-3"
+       width="0.66145885"
+       height="3.9687498"
+       x="98.226562"
+       y="48.286461" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0158876"
+       id="rect414-6"
+       width="0.66145819"
+       height="3.9687498"
+       x="100.54166"
+       y="48.286461" />
+    <rect
+       style="fill:#999999;stroke-width:0.0165364"
+       id="rect1736"
+       width="1.6536455"
+       height="3.9687498"
+       x="94.257812"
+       y="48.286461" />
+    <rect
+       style="fill:#00ccff;stroke-width:0.0165364"
+       id="rect1738"
+       width="1.6536458"
+       height="3.96875"
+       x="96.572914"
+       y="48.286461" />
+    <rect
+       style="fill:#00ccff;stroke-width:0.0165364"
+       id="rect1740"
+       width="1.6536458"
+       height="3.96875"
+       x="98.888016"
+       y="48.286461" />
+    <rect
+       style="fill:#00ccff;stroke-width:0.0165364"
+       id="rect1742"
+       width="1.6536458"
+       height="3.96875"
+       x="101.20312"
+       y="48.286461" />
+  </g>
+</svg>

--- a/src/frontend/qt_sdl/PowerManagement/resources/dsi_batteryalmostempty.svg
+++ b/src/frontend/qt_sdl/PowerManagement/resources/dsi_batteryalmostempty.svg
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="12.236976mm"
+   height="6.2838535mm"
+   viewBox="0 0 12.236976 6.283854"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="dsi_batteryalmostempty.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ff8100"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="1"
+     inkscape:pagecheckerboard="false"
+     inkscape:document-units="mm"
+     showgrid="true"
+     height="200mm"
+     showborder="true"
+     inkscape:showpageshadow="false"
+     borderlayer="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="14.481547"
+     inkscape:cx="35.389866"
+     inkscape:cy="16.503762"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11"
+       spacingx="0.26458333"
+       spacingy="0.26458333"
+       originx="-91.77735"
+       originy="-47.128928" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-91.777344,-47.12891)">
+    <rect
+       style="fill:#ff2a2a;fill-rule:evenodd;stroke-width:0.0211535"
+       id="rect153"
+       width="1.3229166"
+       height="2.9765623"
+       x="91.777344"
+       y="48.782555" />
+    <rect
+       style="fill:#ff2a2a;stroke-width:0.0162915"
+       id="rect177"
+       width="10.914062"
+       height="0.66145831"
+       x="93.100258"
+       y="47.12891" />
+    <rect
+       style="fill:#ff2a2a;stroke-width:0.0165364"
+       id="rect179"
+       width="0.66145831"
+       height="4.9609375"
+       x="93.100258"
+       y="47.790367" />
+    <rect
+       style="fill:#ff2a2a;stroke-width:0.0162915"
+       id="rect181"
+       width="10.914062"
+       height="0.66145873"
+       x="93.100258"
+       y="52.751305" />
+    <rect
+       style="fill:#ff2a2a;stroke-width:0.0165364"
+       id="rect183"
+       width="0.66145831"
+       height="4.9609375"
+       x="103.35286"
+       y="47.790367" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0162585"
+       id="rect318"
+       width="9.5911455"
+       height="0.49609375"
+       x="93.761719"
+       y="47.790367" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0158876"
+       id="rect408"
+       width="0.49609372"
+       height="3.96875"
+       x="93.761719"
+       y="48.286461" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.015706"
+       id="rect410"
+       width="9.5911455"
+       height="0.49609351"
+       x="93.761719"
+       y="52.255211" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0158876"
+       id="rect412"
+       width="0.4960939"
+       height="3.9687498"
+       x="102.85677"
+       y="48.286461" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0224686"
+       id="rect414"
+       width="0.66145849"
+       height="3.9687498"
+       x="95.911453"
+       y="48.286461" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0158876"
+       id="rect414-3"
+       width="0.66145885"
+       height="3.9687498"
+       x="98.226562"
+       y="48.286461" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0158876"
+       id="rect414-6"
+       width="0.66145819"
+       height="3.9687498"
+       x="100.54166"
+       y="48.286461" />
+    <rect
+       style="fill:#999999;stroke-width:0.0165364"
+       id="rect1736"
+       width="1.6536455"
+       height="3.9687498"
+       x="94.257812"
+       y="48.286461" />
+    <rect
+       style="fill:#999999;stroke-width:0.0165364"
+       id="rect1738"
+       width="1.6536458"
+       height="3.96875"
+       x="96.572914"
+       y="48.286461" />
+    <rect
+       style="fill:#999999;stroke-width:0.0165364"
+       id="rect1740"
+       width="1.6536458"
+       height="3.96875"
+       x="98.888016"
+       y="48.286461" />
+    <rect
+       style="fill:#ff2a2a;stroke-width:0.0165364"
+       id="rect1742"
+       width="1.6536458"
+       height="3.96875"
+       x="101.20312"
+       y="48.286461" />
+  </g>
+</svg>

--- a/src/frontend/qt_sdl/PowerManagement/resources/dsi_batteryfull.svg
+++ b/src/frontend/qt_sdl/PowerManagement/resources/dsi_batteryfull.svg
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="12.236976mm"
+   height="6.2838535mm"
+   viewBox="0 0 12.236976 6.283854"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="batteryfull.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ff8100"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="1"
+     inkscape:pagecheckerboard="false"
+     inkscape:document-units="mm"
+     showgrid="true"
+     height="200mm"
+     showborder="true"
+     inkscape:showpageshadow="false"
+     borderlayer="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="10.24"
+     inkscape:cx="2.7832031"
+     inkscape:cy="2.0507813"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11"
+       spacingx="0.26458333"
+       spacingy="0.26458333"
+       originx="-91.777345"
+       originy="-47.128916" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-91.777344,-47.12891)">
+    <rect
+       style="fill:#000000;fill-rule:evenodd;stroke-width:0.0211535"
+       id="rect153"
+       width="1.3229166"
+       height="2.9765623"
+       x="91.777344"
+       y="48.782555" />
+    <rect
+       style="fill:#000000;stroke-width:0.0162915"
+       id="rect177"
+       width="10.914062"
+       height="0.66145831"
+       x="93.100258"
+       y="47.12891" />
+    <rect
+       style="fill:#000000;stroke-width:0.0165364"
+       id="rect179"
+       width="0.66145831"
+       height="4.9609375"
+       x="93.100258"
+       y="47.790367" />
+    <rect
+       style="fill:#000000;stroke-width:0.0162915"
+       id="rect181"
+       width="10.914062"
+       height="0.66145873"
+       x="93.100258"
+       y="52.751305" />
+    <rect
+       style="fill:#000000;stroke-width:0.0165364"
+       id="rect183"
+       width="0.66145831"
+       height="4.9609375"
+       x="103.35286"
+       y="47.790367" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0162585"
+       id="rect318"
+       width="9.5911455"
+       height="0.49609375"
+       x="93.761719"
+       y="47.790367" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0158876"
+       id="rect408"
+       width="0.49609372"
+       height="3.96875"
+       x="93.761719"
+       y="48.286461" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.015706"
+       id="rect410"
+       width="9.5911455"
+       height="0.49609351"
+       x="93.761719"
+       y="52.255211" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0158876"
+       id="rect412"
+       width="0.4960939"
+       height="3.9687498"
+       x="102.85677"
+       y="48.286461" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0224686"
+       id="rect414"
+       width="0.66145849"
+       height="3.9687498"
+       x="95.911453"
+       y="48.286461" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0158876"
+       id="rect414-3"
+       width="0.66145885"
+       height="3.9687498"
+       x="98.226562"
+       y="48.286461" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0158876"
+       id="rect414-6"
+       width="0.66145819"
+       height="3.9687498"
+       x="100.54166"
+       y="48.286461" />
+    <rect
+       style="fill:#00ccff;stroke-width:0.0165364"
+       id="rect1736"
+       width="1.6536455"
+       height="3.9687498"
+       x="94.257812"
+       y="48.286461" />
+    <rect
+       style="fill:#00ccff;stroke-width:0.0165364"
+       id="rect1738"
+       width="1.6536458"
+       height="3.96875"
+       x="96.572914"
+       y="48.286461" />
+    <rect
+       style="fill:#00ccff;stroke-width:0.0165364"
+       id="rect1740"
+       width="1.6536458"
+       height="3.96875"
+       x="98.888016"
+       y="48.286461" />
+    <rect
+       style="fill:#00ccff;stroke-width:0.0165364"
+       id="rect1742"
+       width="1.6536458"
+       height="3.96875"
+       x="101.20312"
+       y="48.286461" />
+  </g>
+</svg>

--- a/src/frontend/qt_sdl/PowerManagement/resources/dsi_batterylow.svg
+++ b/src/frontend/qt_sdl/PowerManagement/resources/dsi_batterylow.svg
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="12.236976mm"
+   height="6.2838535mm"
+   viewBox="0 0 12.236976 6.283854"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="batterylow.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ff8100"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="1"
+     inkscape:pagecheckerboard="false"
+     inkscape:document-units="mm"
+     showgrid="true"
+     height="200mm"
+     showborder="true"
+     inkscape:showpageshadow="false"
+     borderlayer="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="0.45254834"
+     inkscape:cx="325.93203"
+     inkscape:cy="232.01941"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11"
+       spacingx="0.26458333"
+       spacingy="0.26458333"
+       originx="-91.777345"
+       originy="-47.128916" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-91.777344,-47.12891)">
+    <rect
+       style="fill:#000000;fill-rule:evenodd;stroke-width:0.0211535"
+       id="rect153"
+       width="1.3229166"
+       height="2.9765623"
+       x="91.777344"
+       y="48.782555" />
+    <rect
+       style="fill:#000000;stroke-width:0.0162915"
+       id="rect177"
+       width="10.914062"
+       height="0.66145831"
+       x="93.100258"
+       y="47.12891" />
+    <rect
+       style="fill:#000000;stroke-width:0.0165364"
+       id="rect179"
+       width="0.66145831"
+       height="4.9609375"
+       x="93.100258"
+       y="47.790367" />
+    <rect
+       style="fill:#000000;stroke-width:0.0162915"
+       id="rect181"
+       width="10.914062"
+       height="0.66145873"
+       x="93.100258"
+       y="52.751305" />
+    <rect
+       style="fill:#000000;stroke-width:0.0165364"
+       id="rect183"
+       width="0.66145831"
+       height="4.9609375"
+       x="103.35286"
+       y="47.790367" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0162585"
+       id="rect318"
+       width="9.5911455"
+       height="0.49609375"
+       x="93.761719"
+       y="47.790367" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0158876"
+       id="rect408"
+       width="0.49609372"
+       height="3.96875"
+       x="93.761719"
+       y="48.286461" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.015706"
+       id="rect410"
+       width="9.5911455"
+       height="0.49609351"
+       x="93.761719"
+       y="52.255211" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0158876"
+       id="rect412"
+       width="0.4960939"
+       height="3.9687498"
+       x="102.85677"
+       y="48.286461" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0224686"
+       id="rect414"
+       width="0.66145849"
+       height="3.9687498"
+       x="95.911453"
+       y="48.286461" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0158876"
+       id="rect414-3"
+       width="0.66145885"
+       height="3.9687498"
+       x="98.226562"
+       y="48.286461" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.0158876"
+       id="rect414-6"
+       width="0.66145819"
+       height="3.9687498"
+       x="100.54166"
+       y="48.286461" />
+    <rect
+       style="fill:#999999;stroke-width:0.0165364"
+       id="rect1736"
+       width="1.6536455"
+       height="3.9687498"
+       x="94.257812"
+       y="48.286461" />
+    <rect
+       style="fill:#999999;stroke-width:0.0165364"
+       id="rect1738"
+       width="1.6536458"
+       height="3.96875"
+       x="96.572914"
+       y="48.286461" />
+    <rect
+       style="fill:#999999;stroke-width:0.0165364"
+       id="rect1740"
+       width="1.6536458"
+       height="3.96875"
+       x="98.888016"
+       y="48.286461" />
+    <rect
+       style="fill:#ff2a2a;stroke-width:0.0165364"
+       id="rect1742"
+       width="1.6536458"
+       height="3.96875"
+       x="101.20312"
+       y="48.286461" />
+  </g>
+</svg>

--- a/src/frontend/qt_sdl/ROMInfoDialog.cpp
+++ b/src/frontend/qt_sdl/ROMInfoDialog.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2022 melonDS team, WaluigiWare64
+    Copyright 2016-2022 melonDS team
 
     This file is part of melonDS.
 

--- a/src/frontend/qt_sdl/ROMInfoDialog.h
+++ b/src/frontend/qt_sdl/ROMInfoDialog.h
@@ -1,5 +1,5 @@
 /*
-    Copyright 2016-2022 melonDS team, WaluigiWare64
+    Copyright 2016-2022 melonDS team
 
     This file is part of melonDS.
 

--- a/src/frontend/qt_sdl/ROMManager.cpp
+++ b/src/frontend/qt_sdl/ROMManager.cpp
@@ -31,6 +31,8 @@
 
 #include "NDS.h"
 #include "DSi.h"
+#include "SPI.h"
+#include "DSi_I2C.h"
 
 
 namespace ROMManager
@@ -405,11 +407,25 @@ ARCodeFile* GetCheatFile()
 }
 
 
+void SetBatteryLevels()
+{
+    if (NDS::ConsoleType == 1)
+    {
+        DSi_BPTWL::SetBatteryLevel(Config::DSiBatteryLevel);
+        DSi_BPTWL::SetBatteryCharging(Config::DSiBatteryCharging);
+    }
+    else
+    {
+        SPI_Powerman::SetBatteryLevelOkay(Config::DSBatteryLevelOkay);
+    }
+}
+
 void Reset()
 {
     NDS::SetConsoleType(Config::ConsoleType);
     if (Config::ConsoleType == 1) EjectGBACart();
     NDS::Reset();
+    SetBatteryLevels();
 
     if ((CartType != -1) && NDSSave)
     {
@@ -453,6 +469,7 @@ bool LoadBIOS()
     BaseAssetName = "";*/
 
     NDS::Reset();
+    SetBatteryLevels();
     return true;
 }
 
@@ -537,6 +554,7 @@ bool LoadROM(QStringList filepath, bool reset)
         NDS::SetConsoleType(Config::ConsoleType);
         NDS::EjectCart();
         NDS::Reset();
+        SetBatteryLevels();
     }
 
     u32 savelen = 0;

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -61,6 +61,7 @@
 #include "InterfaceSettingsDialog.h"
 #include "ROMInfoDialog.h"
 #include "TitleManagerDialog.h"
+#include "PowerManagement/PowerManagementDialog.h"
 
 #include "types.h"
 #include "version.h"
@@ -1428,6 +1429,11 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
 
         menu->addSeparator();
 
+        actPowerManagement = menu->addAction("Power management");
+        connect(actPowerManagement, &QAction::triggered, this, &MainWindow::onOpenPowerManagement);
+
+        menu->addSeparator();
+
         actEnableCheats = menu->addAction("Enable cheats");
         actEnableCheats->setCheckable(true);
         connect(actEnableCheats, &QAction::triggered, this, &MainWindow::onEnableCheats);
@@ -1664,6 +1670,8 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
     actReset->setEnabled(false);
     actStop->setEnabled(false);
     actFrameStep->setEnabled(false);
+
+    actPowerManagement->setEnabled(false);
 
     actSetupCheats->setEnabled(false);
     actTitleManager->setEnabled(!Config::DSiNANDPath.empty());
@@ -2598,6 +2606,11 @@ void MainWindow::onEmuSettingsDialogFinished(int res)
         actTitleManager->setEnabled(!Config::DSiNANDPath.empty());
 }
 
+void MainWindow::onOpenPowerManagement()
+{
+    PowerManagementDialog* dlg = PowerManagementDialog::openDlg(this);
+}
+
 void MainWindow::onOpenInputConfig()
 {
     emuThread->emuPause();
@@ -2869,6 +2882,8 @@ void MainWindow::onEmuStart()
     actStop->setEnabled(true);
     actFrameStep->setEnabled(true);
 
+    actPowerManagement->setEnabled(true);
+
     actTitleManager->setEnabled(false);
 }
 
@@ -2887,6 +2902,8 @@ void MainWindow::onEmuStop()
     actReset->setEnabled(false);
     actStop->setEnabled(false);
     actFrameStep->setEnabled(false);
+
+    actPowerManagement->setEnabled(false);
 
     actTitleManager->setEnabled(!Config::DSiNANDPath.empty());
 }

--- a/src/frontend/qt_sdl/main.h
+++ b/src/frontend/qt_sdl/main.h
@@ -256,6 +256,7 @@ private slots:
 
     void onOpenEmuSettings();
     void onEmuSettingsDialogFinished(int res);
+    void onOpenPowerManagement();
     void onOpenInputConfig();
     void onInputConfigFinished(int res);
     void onOpenVideoSettings();
@@ -344,6 +345,7 @@ public:
     QAction* actTitleManager;
 
     QAction* actEmuSettings;
+    QAction* actPowerManagement;
     QAction* actInputConfig;
     QAction* actVideoSettings;
     QAction* actAudioSettings;


### PR DESCRIPTION
The DS battery level is configured via the SPI Power Management Device,
and the DSi's is configured via the I2C BPTWL. Add support for changing
these registers and add the "Power Management" dialog in the UI.

![Screenshot from 2022-02-18 15-39-32](https://user-images.githubusercontent.com/68647953/154714067-4e5109b6-d11a-4e7a-9648-2e012b9b5df9.png)


TODO: save these registers to Config and update copyright years.

