### PR TITLE
Added note on how to remove a mapping

### DIFF
--- a/src/frontend/qt_sdl/InputConfig/InputConfigDialog.ui
+++ b/src/frontend/qt_sdl/InputConfig/InputConfigDialog.ui
@@ -30,6 +30,13 @@
      </property>
     </widget>
    </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Note: To clear a mapping, select it and press [Backspace]</string>
+     </property>
+    </widget>
+   </item>
    <item row="6" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <property name="leftMargin">


### PR DESCRIPTION
As noted here https://github.com/Arisotura/melonDS/issues/1461 , added a note on the frontend in the Input and hotkeys page that describes how to clear a mapping.