### PR TITLE
Changes some macros to constexpr functions, templates and lambdas

### DIFF
--- a/src/DSi.cpp
+++ b/src/DSi.cpp
@@ -295,34 +295,34 @@ void DecryptModcryptArea(u32 offset, u32 size, u8* iv)
     // CHECKME: GBAtek says the modcrypt area should be the same size, or bigger,
     // than the binary area being considered
     // but I have seen modcrypt areas smaller than the ARM9i binary
-#define BINARY_GOOD(name) \
-    ((offset >= NDSCart::Header.name##ROMOffset) && \
-     (offset+roundedsize) <= (NDSCart::Header.name##ROMOffset + ((NDSCart::Header.name##Size + 0xF) & ~0xF)))
+    const auto binaryGood = [offset, roundedsize](u32 ROMOffset, u32 size)
+    {
+        return ((offset >= ROMOffset) &&
+            (offset+roundedsize) <= (ROMOffset + ((size + 0xF) & ~0xF)));
+    };
 
-    if (BINARY_GOOD(ARM9))
+    if (binaryGood(NDSCart::Header.ARM9ROMOffset, NDSCart::Header.ARM9Size))
     {
         binaryaddr = NDSCart::Header.ARM9RAMAddress;
         binarysize = NDSCart::Header.ARM9Size;
     }
-    else if (BINARY_GOOD(ARM7))
+    else if (binaryGood(NDSCart::Header.ARM7ROMOffset, NDSCart::Header.ARM7Size))
     {
         binaryaddr = NDSCart::Header.ARM7RAMAddress;
         binarysize = NDSCart::Header.ARM7Size;
     }
-    else if (BINARY_GOOD(DSiARM9i))
+    else if (binaryGood(NDSCart::Header.DSiARM9iROMOffset, NDSCart::Header.DSiARM9iSize))
     {
         binaryaddr = NDSCart::Header.DSiARM9iRAMAddress;
         binarysize = NDSCart::Header.DSiARM9iSize;
     }
-    else if (BINARY_GOOD(DSiARM7i))
+    else if (binaryGood(NDSCart::Header.DSiARM7iROMOffset, NDSCart::Header.DSiARM7iSize))
     {
         binaryaddr = NDSCart::Header.DSiARM7iRAMAddress;
         binarysize = NDSCart::Header.DSiARM7iSize;
     }
     else
         return;
-
-#undef BINARY_GOOD
 
     for (u32 i = 0; i < size; i+=16)
     {

--- a/src/DSi_SD.cpp
+++ b/src/DSi_SD.cpp
@@ -44,7 +44,10 @@
 // * when filling FIFO
 
 
-#define SD_DESC  Num?"SDIO":"SD/MMC"
+constexpr auto SDDesc(u32 Num)
+{
+    return Num ? "SDIO" : "SD/MMC";
+};
 
 
 DSi_SDHost::DSi_SDHost(u32 num)
@@ -522,7 +525,7 @@ u16 DSi_SDHost::Read(u32 addr)
     case 0x10A: return 0;
     }
 
-    printf("unknown %s read %08X @ %08X\n", SD_DESC, addr, NDS::GetPC(1));
+    printf("unknown %s read %08X @ %08X\n", SDDesc(Num), addr, NDS::GetPC(1));
     return 0;
 }
 
@@ -590,11 +593,11 @@ void DSi_SDHost::Write(u32 addr, u16 val)
                 case 0: dev->SendCMD(cmd, Param); break;
                 case 1: /*dev->SendCMD(55, 0);*/ dev->SendCMD(cmd, Param); break;
                 default:
-                    printf("%s: unknown command type %d, %02X %08X\n", SD_DESC, (Command>>6)&0x3, cmd, Param);
+                    printf("%s: unknown command type %d, %02X %08X\n", SDDesc(Num), (Command>>6)&0x3, cmd, Param);
                     break;
                 }
             }
-            else printf("%s: SENDING CMD %04X TO NULL DEVICE\n", SD_DESC, val);
+            else printf("%s: SENDING CMD %04X TO NULL DEVICE\n", SDDesc, val);
         }
         return;
 
@@ -658,7 +661,7 @@ void DSi_SDHost::Write(u32 addr, u16 val)
     case 0x0E0:
         if ((SoftReset & 0x0001) && !(val & 0x0001))
         {
-            printf("%s: RESET\n", SD_DESC);
+            printf("%s: RESET\n", SDDesc(Num));
             StopAction = 0;
             memset(ResponseBuffer, 0, sizeof(ResponseBuffer));
             IRQStatus = 0;
@@ -688,7 +691,7 @@ void DSi_SDHost::Write(u32 addr, u16 val)
     case 0x10A: return;
     }
 
-    printf("unknown %s write %08X %04X\n", SD_DESC, addr, val);
+    printf("unknown %s write %08X %04X\n", SDDesc(Num), addr, val);
 }
 
 void DSi_SDHost::WriteFIFO16(u16 val)
@@ -698,7 +701,7 @@ void DSi_SDHost::WriteFIFO16(u16 val)
     if (DataFIFO[f].IsFull())
     {
         // TODO
-        printf("!!!! %s FIFO (16) FULL\n", SD_DESC);
+        printf("!!!! %s FIFO (16) FULL\n", SDDesc(Num));
         return;
     }
 
@@ -714,7 +717,7 @@ void DSi_SDHost::WriteFIFO32(u32 val)
     if (DataFIFO32.IsFull())
     {
         // TODO
-        printf("!!!! %s FIFO (32) FULL\n", SD_DESC);
+        printf("!!!! %s FIFO (32) FULL\n", SDDesc(Num));
         return;
     }
 

--- a/src/GPU_OpenGL.cpp
+++ b/src/GPU_OpenGL.cpp
@@ -60,30 +60,29 @@ bool GLCompositor::Init()
     }
 
     // all this mess is to prevent bleeding
-#define SETVERTEX(i, x, y, offset) \
-    CompVertices[i].Position[0] = x; \
-    CompVertices[i].Position[1] = y + offset; \
-    CompVertices[i].Texcoord[0] = (x + 1.f) * (256.f / 2.f); \
-    CompVertices[i].Texcoord[1] = (y + 1.f) * (384.f / 2.f)
-
+    const auto setVertex = [this](u32 i, s32 x, s32 y, float offset)
+    {
+        CompVertices[i].Position[0] = x;
+        CompVertices[i].Position[1] = y + offset;
+        CompVertices[i].Texcoord[0] = (x + 1.f) * (256.f / 2.f);
+        CompVertices[i].Texcoord[1] = (y + 1.f) * (384.f / 2.f);
+    };
     const float padOffset = 1.f/(192*2.f+2.f)*2.f;
     // top screen
-    SETVERTEX(0, -1, 1, 0);
-    SETVERTEX(1, 1, 0, padOffset);
-    SETVERTEX(2, 1, 1, 0);
-    SETVERTEX(3, -1, 1, 0);
-    SETVERTEX(4, -1, 0, padOffset);
-    SETVERTEX(5, 1, 0, padOffset);
+    setVertex(0, -1, 1, 0);
+    setVertex(1, 1, 0, padOffset);
+    setVertex(2, 1, 1, 0);
+    setVertex(3, -1, 1, 0);
+    setVertex(4, -1, 0, padOffset);
+    setVertex(5, 1, 0, padOffset);
 
     // bottom screen
-    SETVERTEX(6, -1, 0, -padOffset);
-    SETVERTEX(7, 1, -1, 0);
-    SETVERTEX(8, 1, 0, -padOffset);
-    SETVERTEX(9, -1, 0, -padOffset);
-    SETVERTEX(10, -1, -1, 0);
-    SETVERTEX(11, 1, -1, 0);
-
-#undef SETVERTEX
+    setVertex(6, -1, 0, -padOffset);
+    setVertex(7, 1, -1, 0);
+    setVertex(8, 1, 0, -padOffset);
+    setVertex(9, -1, 0, -padOffset);
+    setVertex(10, -1, -1, 0);
+    setVertex(11, 1, -1, 0);
 
     glGenBuffers(1, &CompVertexBufferID);
     glBindBuffer(GL_ARRAY_BUFFER, CompVertexBufferID);

--- a/src/WifiAP.h
+++ b/src/WifiAP.h
@@ -24,10 +24,9 @@
 namespace WifiAP
 {
 
-#define AP_MAC  0x00, 0xF0, 0x77, 0x77, 0x77, 0x77
-#define AP_NAME "melonAP"
+constexpr const char* APName = "melonAP";
 
-extern const u8 APMac[6];
+constexpr u8 APMac[6] = {0x00, 0xF0, 0x77, 0x77, 0x77, 0x77};
 
 bool Init();
 void DeInit();


### PR DESCRIPTION
It's generally a good goal to keep macro usage to a minimum, so I changed some macros to equivalent but type safe code.

- In WifiAP.cpp PWRITEs turned into constexpr function template + a few other constexpr functions. In WifiAP.h AP_MAC and AP_NAME turned into constexpr constants.
- In GPU_OpenGL.cpp SETVERTEX turned into a lambda.
- In DSi_SD.cpp SD_DESC turned into a constexpr function.
- In DSi.cpp BINARY_GOOD turned into a lambda.